### PR TITLE
Restructure tree items and rework test execution to use stream file option

### DIFF
--- a/examples/rpgsqlstmf.test.sqlrpgle
+++ b/examples/rpgsqlstmf.test.sqlrpgle
@@ -37,13 +37,8 @@
 ctl-opt NoMain Option(*SrcStmt : *NoDebugIO);
 dcl-f QSYSPRT printer(80) oflind(*in70) usropn;
 
-/if defined(IRPGUNIT_STMF)
-/include qinclude/TESTCASE.RPGLE            iRPGUnit Test Suite
-/include qinclude/SDS.RPGLE                 Program status data structure
-/else
-/include qinclude,TESTCASE.RPGLE            iRPGUnit Test Suite
-/include qinclude,SDS.RPGLE                 Program status data structure
-/endif
+/include qinclude,TESTCASE                  iRPGUnit Test Suite
+/include qinclude,SDS                       Program status data structure
 
 // ------------------------------------------------------------
 //  SQL Options.

--- a/examples/rpgstmf.test.rpgle
+++ b/examples/rpgstmf.test.rpgle
@@ -37,13 +37,8 @@
 ctl-opt NoMain Option(*SrcStmt : *NoDebugIO);
 dcl-f QSYSPRT printer(80) oflind(*in70) usropn;
 
-/if defined(IRPGUNIT_STMF)
-/include qinclude/TESTCASE.RPGLE            iRPGUnit Test Suite
-/include qinclude/SDS.RPGLE                 Program status data structure
-/else
-/include qinclude,TESTCASE.RPGLE            iRPGUnit Test Suite
-/include qinclude,SDS.RPGLE                 Program status data structure
-/endif
+/include qinclude,TESTCASE                  iRPGUnit Test Suite
+/include qinclude,SDS                       Program status data structure
 
 // ------------------------------------------------------------
 //  Global type templates.

--- a/examples/sub/rpgsqlstmf.test.sqlrpgle
+++ b/examples/sub/rpgsqlstmf.test.sqlrpgle
@@ -37,13 +37,8 @@
 ctl-opt NoMain Option(*SrcStmt : *NoDebugIO);
 dcl-f QSYSPRT printer(80) oflind(*in70) usropn;
 
-/if defined(IRPGUNIT_STMF)
-/include qinclude/TESTCASE.RPGLE            iRPGUnit Test Suite
-/include qinclude/SDS.RPGLE                 Program status data structure
-/else
-/include qinclude,TESTCASE.RPGLE            iRPGUnit Test Suite
-/include qinclude,SDS.RPGLE                 Program status data structure
-/endif
+/include qinclude,TESTCASE                  iRPGUnit Test Suite
+/include qinclude,SDS                       Program status data structure
 
 // ------------------------------------------------------------
 //  SQL Options.

--- a/examples/sub/rpgstmf.test.rpgle
+++ b/examples/sub/rpgstmf.test.rpgle
@@ -37,13 +37,8 @@
 ctl-opt NoMain Option(*SrcStmt : *NoDebugIO);
 dcl-f QSYSPRT printer(80) oflind(*in70) usropn;
 
-/if defined(IRPGUNIT_STMF)
-/include qinclude/TESTCASE.RPGLE            iRPGUnit Test Suite
-/include qinclude/SDS.RPGLE                 Program status data structure
-/else
-/include qinclude,TESTCASE.RPGLE            iRPGUnit Test Suite
-/include qinclude,SDS.RPGLE                 Program status data structure
-/endif
+/include qinclude,TESTCASE                  iRPGUnit Test Suite
+/include qinclude,SDS                       Program status data structure
 
 // ------------------------------------------------------------
 //  Global type templates.

--- a/examples/sub/testing.json
+++ b/examples/sub/testing.json
@@ -1,10 +1,8 @@
 {
     "RUCRTRPG": {
-        "text": "Sub testing.json",
-        "tgtCcsid": "37"
+        "text": "Sub testing.json"
     },
     "RUCRTCBL": {
-        "text": "Sub testing.json",
-        "tgtCcsid": "37"
+        "text": "Sub testing.json"
     }
 }

--- a/examples/testing.json
+++ b/examples/testing.json
@@ -1,10 +1,8 @@
 {
     "RUCRTRPG": {
-        "text": "Root testing.json",
-        "tgtCcsid": "37"
+        "text": "Root testing.json"
     },
     "RUCRTCBL": {
-        "text": "Root testing.json",
-        "tgtCcsid": "37"
+        "text": "Root testing.json"
     }
 }

--- a/src/api/ibmi.ts
+++ b/src/api/ibmi.ts
@@ -1,5 +1,6 @@
 import { CodeForIBMi } from "@halcyontech/vscode-ibmi-types";
 import Instance from "@halcyontech/vscode-ibmi-types/api/Instance";
+import { DeployTools } from "@halcyontech/vscode-ibmi-types/api/local/deployTools";
 import { Extension, extensions } from "vscode";
 
 let baseExtension: Extension<CodeForIBMi> | undefined;
@@ -14,4 +15,8 @@ export function loadBase(): CodeForIBMi | undefined {
 
 export function getInstance(): Instance | undefined {
     return (baseExtension && baseExtension.isActive && baseExtension.exports ? baseExtension.exports.instance : undefined);
+}
+
+export function getDeployTools(): typeof DeployTools | undefined {
+  return (baseExtension && baseExtension.isActive && baseExtension.exports ? baseExtension.exports.deployTools : undefined);
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,11 +1,13 @@
-import { TestRunRequest, TestItem, TestMessage, Location, CancellationToken, TestRun } from "vscode";
+import { TestRunRequest, TestItem, TestMessage, Location, CancellationToken, TestRun, workspace, window } from "vscode";
 import { IBMiTestData, IBMiTestManager } from "./manager";
 import { TestFile } from "./testFile";
-import { getInstance } from "./api/ibmi";
+import { getDeployTools, getInstance } from "./api/ibmi";
 import * as path from "path";
 import { parseStringPromise } from "xml2js";
-import { RUCALLTST } from "./types";
+import { RUCALLTST, TestQueue } from "./types";
 import { Configuration, defaultConfigurations, Section } from "./configuration";
+import { TestCase } from "./testCase";
+import { TestDirectory } from "./testDirectory";
 
 export class IBMiTestRunner {
     public static TEST_OUTPUT_DIRECTORY: string = 'vscode-ibmi-testing';
@@ -19,33 +21,52 @@ export class IBMiTestRunner {
         this.token = token;
     }
 
-    async getTestQueue(run: TestRun): Promise<{ item: TestItem; data: IBMiTestData; }[]> {
-        const queue: { item: TestItem, data: IBMiTestData }[] = [];
+    async getTestQueue(run: TestRun): Promise<TestQueue> {
+        const queue: TestQueue = [];
 
-        let items: any = [];
+        // Gather initial set of requested test items to run
+        let requestedItems: any = [];
         if (this.request.include) {
-            items = this.request.include;
+            requestedItems = this.request.include;
         } else {
             this.manager.controller.items.forEach((item) => {
-                items.push(item);
+                requestedItems.push(item);
             });
         }
 
-        for (const item of items) {
-            if (this.request.exclude?.includes(item)) {
-                continue;
-            }
-
-            const data = this.manager.testData.get(item)!;
-            if (data instanceof TestFile) {
-                await data.load();
-            }
-
-            run.enqueued(item);
-            queue.push({ item, data });
+        for (const requestItem of requestedItems) {
+            await this.processRequest(requestItem, run, queue);
         }
 
         return queue;
+    }
+
+    async processRequest(item: TestItem, run: TestRun, queue: TestQueue): Promise<void> {
+        if (this.request.exclude?.includes(item)) {
+            return;
+        }
+
+        const data = this.manager.testData.get(item)!;
+        if (data instanceof TestDirectory) {
+            // Request is a test directory so process children
+            const childRequestItems: any = [];
+            item.children.forEach((item) => {
+                childRequestItems.push(item);
+            });
+            for (const childRequestItem of childRequestItems) {
+                await this.processRequest(childRequestItem, run, queue);
+            }
+        } else if (data instanceof TestFile) {
+            // Request is a test file so load data and add to queue
+            await data.load();
+            queue.push({ item, data });
+        } else if (data instanceof TestCase) {
+            // Request is a test case so add to queue
+            queue.push({ item, data });
+        }
+
+        // Add item to test run queue
+        run.enqueued(item);
     }
 
     async runHandler(): Promise<void> {
@@ -60,23 +81,61 @@ export class IBMiTestRunner {
 
         const queue: { item: TestItem, data: IBMiTestData }[] = await this.getTestQueue(run);
 
-        const compiledTestFiles: TestItem[] = [];
+        const attemptedDeployments: { workspaceItem: TestItem, isDeployed: boolean }[] = [];
+        const compiledTestFileItems: TestItem[] = [];
         for (const { item, data } of queue) {
             const testFileItem = data instanceof TestFile ? item : item.parent!;
             const testFileData = data instanceof TestFile ? data : this.manager.testData.get(testFileItem)! as TestFile;
 
-            let compiledTestFile = compiledTestFiles.find((testFile) => testFile.id === testFileItem.id);
-            if (!compiledTestFile) {
-                IBMiTestRunner.updateTestRunStatus(run, 'testFile', { item: testFileItem });
+            // Deploy workspace folder associated with test file if not already attemptted
+            // TODO: Handle remote case where deploy is ignored (maybe track remote or local in TestFile?)
+            const workspaceFolder = workspace.getWorkspaceFolder(testFileData.workspaceItem.uri!);
+            let attempt = attemptedDeployments.find((attempt) => attempt.workspaceItem.uri?.toString() === workspaceFolder!.uri.toString());
+            if (!attempt) {
+                IBMiTestRunner.updateTestRunStatus(run, 'workspaceFolder', { item: testFileData.workspaceItem });
 
-                if (testFileData.isCompiled) {
-                    IBMiTestRunner.updateTestRunStatus(run, 'compilation', { compilationResult: 'Compilation Skipped' });
+                const deployTools = getDeployTools();
+                const deployResult = await deployTools!.launchDeploy(workspaceFolder!.index);
+                attempt = { workspaceItem: testFileData.workspaceItem, isDeployed: deployResult ? true : false };
+                attemptedDeployments.push(attempt);
+
+                if (deployResult) {
+                    IBMiTestRunner.updateTestRunStatus(run, 'deployment', { result: 'Deployment Successful' });
                 } else {
-                    await testFileData.compileMember(run);
-                    compiledTestFiles.push(testFileItem);
+                    IBMiTestRunner.updateTestRunStatus(run, 'deployment', { result: 'Deployment Failed' });
                 }
             }
 
+            // Error out children if workspace folder not deployed
+            // TODO: Fix test file name and directory not being displayed in test results view
+            if (!attempt.isDeployed) {
+                if (data instanceof TestFile) {
+                    item.children.forEach((childItem) => {
+                        if (!this.request.exclude?.includes(childItem)) {
+                            IBMiTestRunner.updateTestRunStatus(run, 'testCase', { item: childItem, errored: true, messages: ['Source must be deployed'] });
+                        }
+                    });
+                } else {
+                    IBMiTestRunner.updateTestRunStatus(run, 'testCase', { item: item, errored: true, messages: ['Source must be deployed'] });
+                }
+
+                continue;
+            }
+
+            // Compile test file if not already compiled
+            const compiledTestFileItem = compiledTestFileItems.find((testFile) => testFile.id === testFileItem.id);
+            if (!compiledTestFileItem) {
+                IBMiTestRunner.updateTestRunStatus(run, 'testFile', { item: testFileItem });
+
+                if (testFileData.isCompiled) {
+                    IBMiTestRunner.updateTestRunStatus(run, 'compilation', { result: 'Compilation Skipped' });
+                } else {
+                    await testFileData.compileMember(run);
+                    compiledTestFileItems.push(testFileItem);
+                }
+            }
+
+            // Error out children if test file is not compiled
             if (!testFileData.isCompiled) {
                 if (data instanceof TestFile) {
                     item.children.forEach((childItem) => {
@@ -87,6 +146,7 @@ export class IBMiTestRunner {
                 } else {
                     IBMiTestRunner.updateTestRunStatus(run, 'testCase', { item: item, errored: true, messages: ['Source must be compiled'] });
                 }
+
                 continue;
             }
 
@@ -111,15 +171,23 @@ export class IBMiTestRunner {
         const content = ibmi!.getContent();
         const config = ibmi!.getConfig();
 
-        // TODO: Again, RPGUNIT library must be on the library list
-        // TODO: Add COBOL support
-        // TODO: Make case insensitive
         const library = item.uri?.scheme === 'file' ? config.currentLibrary : connection.parserMemberPath(item.uri!.path).library;
-        const programName = (item.parent?.label || item.label).replace(new RegExp(IBMiTestManager.RPGLE_TEST_SUFFIX, 'i'), IBMiTestManager.TEST_SUFFIX).toLocaleUpperCase();
+        const data = this.manager.testData.get(item);
+        const isTestCase = data instanceof TestCase;
+        let programName =
+            isTestCase ?
+                item.parent!.label :
+                item.label;
+        programName = programName
+            .replace(new RegExp(IBMiTestManager.RPGLE_TEST_SUFFIX, 'i'), '')
+            .replace(new RegExp(IBMiTestManager.SQLRPGLE_TEST_SUFFIX, 'i'), '')
+            .replace(new RegExp(IBMiTestManager.COBOL_TEST_SUFFIX, 'i'), '')
+            .replace(new RegExp(IBMiTestManager.SQLCOBOL_TEST_SUFFIX, 'i'), '')
+            .toLocaleUpperCase();
 
         const tstpgm = `${library}/${programName}`;
-        const tstprc = item.parent ? item.label : undefined;
-        const xmlstmf = path.posix.join(config.tempDir, IBMiTestRunner.TEST_OUTPUT_DIRECTORY, `${programName}${tstprc ? `-${tstprc}` : ``}.xml`) // TODO: Where to put the xml file? Need to delete it eventually?
+        const tstprc = isTestCase ? item.label : undefined;
+        const xmlstmf = path.posix.join(config.tempDir, IBMiTestRunner.TEST_OUTPUT_DIRECTORY, `${programName}${tstprc ? `-${tstprc}` : ``}.xml`);
 
         const testParams: RUCALLTST = {
             tstPgm: tstpgm,
@@ -146,7 +214,9 @@ export class IBMiTestRunner {
             const rawXml = (await content.downloadStreamfileRaw(testParams.xmlStmf));
             parsedXml = await parseStringPromise(rawXml);
         } catch (error) {
+            // TODO: How to properly handle when testResult exit code is 0
             // TODO: Need to call updateTestRunStatus on TestItem, but what to log (xml parse error or stdout from testResult)?
+            window.showErrorMessage(`Error parsing XML file. Error ${error}`);
         }
 
         // TODO: How to get actual and expected value for failed test cases to show diff style output message
@@ -154,10 +224,10 @@ export class IBMiTestRunner {
             const duration: number = 0;// TODO: Get duration from XML
 
             let mappedItem: TestItem;
-            if (!item.parent) {
-                mappedItem = item.children.get(`${item.uri}/${testcase.$.name}`)!;
-            } else {
+            if (isTestCase) {
                 mappedItem = item;
+            } else {
+                mappedItem = item.children.get(`${item.uri}/${testcase.$.name}`)!;
             }
 
             // TODO: Need to handle test case errors
@@ -170,14 +240,15 @@ export class IBMiTestRunner {
     }
 
     // TODO: Fix data to have a type instead of any
-    static updateTestRunStatus(run: TestRun, type: 'testFile' | 'upload' | 'compilation' | 'testCase' | 'metrics', data?: any): void {
+    static updateTestRunStatus(run: TestRun, type: 'workspaceFolder' | 'testFile' | 'deployment' | 'compilation' | 'testCase' | 'metrics', data?: any): void {
         switch (type) {
+            case 'workspaceFolder':
             case 'testFile':
                 run.appendOutput(data.item.label);
                 break;
-            case 'upload':
+            case 'deployment':
             case 'compilation':
-                run.appendOutput(` (${data.compilationResult})\r\n`);
+                run.appendOutput(` (${data.result})\r\n`);
                 if (data.messages) {
                     for (const message of data.messages) {
                         run.appendOutput(`\t• ${message}\r\n`);

--- a/src/testFile.ts
+++ b/src/testFile.ts
@@ -1,7 +1,7 @@
 import { commands, DocumentSymbol, SymbolKind, TestItem, TestRun, workspace } from "vscode";
 import { TestCase } from "./testCase";
 import { manager } from "./extension";
-import { getInstance } from "./api/ibmi";
+import { getDeployTools, getInstance } from "./api/ibmi";
 import { IBMiTestManager } from "./manager";
 import { IBMiTestRunner } from "./runner";
 import { TestingConfig, RUCRTRPG } from "./types";
@@ -14,13 +14,15 @@ export class TestFile {
     static COBOL_TEST_CASE_REGEX = /^PROGRAM-ID\. +(TEST.+)$/i;
     static textDecoder = new TextDecoder('utf-8');
     item: TestItem;
+    workspaceItem: TestItem;
     isLoaded: boolean;
     isCompiled: boolean;
     content: string;
     isRPGLE: boolean;
 
-    constructor(item: TestItem) {
+    constructor(item: TestItem, workspaceItem: TestItem) {
         this.item = item;
+        this.workspaceItem = workspaceItem;
         this.isLoaded = false;
         this.isCompiled = false;
         this.content = '';
@@ -79,84 +81,64 @@ export class TestFile {
         const content = ibmi!.getContent();
         const config = ibmi!.getConfig();
 
-        let library: string;
-        let srcPf: string;
-        let mbr: string;
-        let mbrType: string;
+        let tstPgm: { name: string, library: string };
+        let srcFile: { name: string, library: string } | undefined;
+        let srcMbr: string | undefined;
+        let srcStmf: string | undefined;
         let testingConfig: TestingConfig | undefined;
-        let isUploaded: boolean;
 
-        if (this.item.uri?.scheme === 'file') {
-            library = config.currentLibrary;
-            srcPf = 'TEMP'; // TODO: What should this be? The parent directory?
-            // TODO: Add COBOL support
-            // TODO: Make case insensitive
-            mbr = this.item.label.replace(new RegExp(IBMiTestManager.RPGLE_TEST_SUFFIX, 'i'), IBMiTestManager.TEST_SUFFIX).toLocaleUpperCase();
-            mbrType = path.parse(this.item.uri.path).ext.substring(1).toLocaleUpperCase();
-            testingConfig = await ConfigHandler.getLocalConfig(this.item.uri);
-            isUploaded = await this.uploadMember(run, library, srcPf, mbr, mbrType);
+        if (this.item.uri!.scheme === 'file') {
+            // Get relative local path to test
+            const workspaceFolder = workspace.getWorkspaceFolder(this.item.uri!)!;
+            const relativePathToTest = path.relative(workspaceFolder.uri.fsPath, this.item.uri!.fsPath).replace(/\\/g, '/');
+
+            // Construct remote path to test
+            const deployTools = getDeployTools()!;
+            const deployDirectory = deployTools.getRemoteDeployDirectory(workspaceFolder)!;
+            if (deployDirectory) {
+                srcStmf = path.posix.join(deployDirectory, relativePathToTest);
+            } else {
+                IBMiTestRunner.updateTestRunStatus(run, 'deployment', { result: 'Deploy Location Not Set' });
+            }
+
+            const tstPgmName = this.item.label
+                .replace(new RegExp(IBMiTestManager.RPGLE_TEST_SUFFIX, 'i'), '')
+                .replace(new RegExp(IBMiTestManager.SQLRPGLE_TEST_SUFFIX, 'i'), '')
+                .replace(new RegExp(IBMiTestManager.COBOL_TEST_SUFFIX, 'i'), '')
+                .replace(new RegExp(IBMiTestManager.SQLCOBOL_TEST_SUFFIX, 'i'), '')
+                .toLocaleUpperCase();
+            tstPgm = { name: tstPgmName, library: config.currentLibrary };
+            testingConfig = await ConfigHandler.getLocalConfig(this.item.uri!);
         } else {
             const parsedPath = connection.parserMemberPath(this.item.uri!.path);
-            library = parsedPath.library;
-            srcPf = parsedPath.file;
-            mbr = parsedPath.name.toLocaleUpperCase();
-            mbrType = parsedPath.extension;
+            tstPgm = { name: parsedPath.name.toLocaleUpperCase(), library: parsedPath.library };
+            srcFile = { name: parsedPath.file, library: parsedPath.library };
+            srcMbr = '*TSTPGM';
             testingConfig = await ConfigHandler.getRemoteConfig(this.item.uri!);
-            isUploaded = true;
         }
 
         const compileParams: RUCRTRPG = {
-            tstPgm: `${library}/${mbr}`,
-            srcFile: `${library}/${srcPf}`,
-            srcMbr: mbr,
+            tstPgm: `${tstPgm.library}/${tstPgm.name}`,
+            srcFile: srcFile ? `${srcFile.library}/${srcFile.name}` : undefined,
+            srcMbr: srcMbr,
+            srcStmf: srcStmf,
             ...testingConfig?.RUCRTRPG
         };
 
-        if (isUploaded) {
-            // TODO: Add support for RUCRTCBL
-            const productLibrary = Configuration.get<string>(Section.productLibrary) || defaultConfigurations[Section.productLibrary];
-            const compileCommand = content.toCl(`${productLibrary}/RUCRTRPG`, compileParams as any);
-            const compileResult = await connection.runCommand({ command: compileCommand, environment: `ile` });
-            if (compileResult.code !== 0) {
-                IBMiTestRunner.updateTestRunStatus(run, 'compilation', { compilationResult: 'Compilation Failed', messages: compileResult.stderr.split('\n') });
-            } else {
-                IBMiTestRunner.updateTestRunStatus(run, 'compilation', { compilationResult: 'Compilation Successful' });
-                this.isCompiled = true;
-                return;
-            }
-        }
-    }
-
-    private async uploadMember(run: TestRun, library: string, srcPf: string, mbr: string, mbrType: string): Promise<boolean> {
-        const ibmi = getInstance();
-        const connection = ibmi!.getConnection();
-        const content = ibmi!.getContent();
-
-        const commands = [
-            content.toCl(`CRTSRCPF`, { file: `${library}/${srcPf}`, rcdlen: 112 }),
-            content.toCl(`ADDPFM`, { file: `${library}/${srcPf}`, mbr: mbr, srcType: mbrType }),
-        ];
-
-        for (const command of commands) {
-            try {
-                const result = await connection.runCommand({ command: command, environment: `ile`, noLibList: true });
-                console.log(result);
-            } catch (error) {
-                // Ignore error as source file and member may already exist
-                // TODO: Need to check for other types of errors?
-            }
+        // Set TGTCCSID to 37 by default if not set
+        if (!compileParams.tgtCcsid) {
+            compileParams.tgtCcsid = "37";
         }
 
-        let isUploaded: boolean = false;
-        try {
-            isUploaded = await content.uploadMemberContent(undefined, library, srcPf, mbr, this.content);
-            if (!isUploaded) {
-                IBMiTestRunner.updateTestRunStatus(run, 'upload', { compilationResult: 'Source Upload Failed' });
-            }
-        } catch (error: any) {
-            IBMiTestRunner.updateTestRunStatus(run, 'upload', { compilationResult: 'Source Upload Failed', messages: error.message.split('\n') });
+        const productLibrary = Configuration.get<string>(Section.productLibrary) || defaultConfigurations[Section.productLibrary];
+        const languageSpecificCommand = this.isRPGLE ? 'RUCRTRPG' : 'RUCRTCBL';
+        const compileCommand = content.toCl(`${productLibrary}/${languageSpecificCommand}`, compileParams as any);
+        const compileResult = await connection.runCommand({ command: compileCommand, environment: `ile` });
+        if (compileResult.code !== 0) {
+            IBMiTestRunner.updateTestRunStatus(run, 'compilation', { result: 'Compilation Failed', messages: compileResult.stderr.split('\n') });
+        } else {
+            IBMiTestRunner.updateTestRunStatus(run, 'compilation', { result: 'Compilation Successful' });
+            this.isCompiled = true;
         }
-
-        return isUploaded;
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,8 @@
+import { TestItem } from "vscode";
+import { IBMiTestData } from "./manager";
+
+export type TestQueue = { item: TestItem, data: IBMiTestData }[];
+
 export interface TestingConfig {
     RUCRTRPG?: RUCRTRPG,
     RUCRTCBL?: RUCRTCBL


### PR DESCRIPTION
### Changes
- Restructure `Testing` view to include workspace and directory level tree items
- Fix naming restriction by excluding `.TEST.RPGLE` in test program name
- Rework test execution to use stream file option for local case
- Initial work for executing COBOL tests
- Use 37 as default TGTCCSID