### PR TITLE
Set `COPTION` to `*EVENTF` by default and retrieve diagnostics

### DIFF
--- a/src/testFile.ts
+++ b/src/testFile.ts
@@ -1,4 +1,4 @@
-import { commands, DocumentSymbol, LogLevel, SymbolKind, TestItem, TestRun, workspace } from "vscode";
+import { commands, DocumentSymbol, LogLevel, SymbolKind, TestItem, TestRun, workspace, WorkspaceFolder } from "vscode";
 import { TestCase } from "./testCase";
 import { manager } from "./extension";
 import { getDeployTools, getInstance } from "./api/ibmi";
@@ -83,6 +83,8 @@ export class TestFile {
         const content = connection.getContent();
         const config = connection.getConfig();
 
+        let workspaceFolder: WorkspaceFolder | undefined;
+
         let tstPgm: { name: string, library: string };
         let srcFile: { name: string, library: string } | undefined;
         let srcMbr: string | undefined;
@@ -91,7 +93,7 @@ export class TestFile {
 
         if (this.item.uri!.scheme === 'file') {
             // Get relative local path to test
-            const workspaceFolder = workspace.getWorkspaceFolder(this.item.uri!)!;
+            workspaceFolder = workspace.getWorkspaceFolder(this.item.uri!)!;
             const relativePathToTest = path.relative(workspaceFolder.uri.fsPath, this.item.uri!.fsPath).replace(/\\/g, '/');
 
             // Construct remote path to test
@@ -143,9 +145,14 @@ export class TestFile {
             };
         }
 
-        // Set TGTCCSID to 37 by default if not set
+        // Set TGTCCSID to 37 by default
         if (!compileParams.tgtCcsid) {
             compileParams.tgtCcsid = "37";
+        }
+
+        // SET COPTION to *EVEVENTF by default to be able to later get diagnostic messages
+        if (!compileParams.cOption) {
+            compileParams.cOption = "*EVENTF";
         }
 
         // Set DBGVIEW to *SOURCE by default for code coverage to get proper line numbers
@@ -161,6 +168,9 @@ export class TestFile {
         let compileResult: any;
         try {
             compileResult = await connection.runCommand({ command: compileCommand, environment: `ile` });
+            if (compileParams.cOption === "*EVENTF") {
+                await commands.executeCommand('code-for-ibmi.openErrors', compileParams.tstPgm, workspaceFolder);
+            }
         } catch (error: any) {
             runner.updateTestRunStatus(run, 'compilation', {
                 item: this.item,


### PR DESCRIPTION
TODO:
- [ ] Code4i API change: [SanjulaGanepola:vscode-ibmi:feature/open-errors-workspace](https://github.com/codefori/vscode-ibmi/compare/master...SanjulaGanepola:vscode-ibmi:feature/open-errors-workspace)
- [ ] How to handle multiple test files being run as each compile clears the previous compile's diagnostics
- [ ] Diagnostics not being pulled for `.sqlrpgle` files