### PR TITLE
More improvements to test stub generation

### DIFF
--- a/src/codeActions/lspUtils.ts
+++ b/src/codeActions/lspUtils.ts
@@ -3,7 +3,7 @@ import Cache from "vscode-rpgle/language/models/cache";
 import { Uri, commands } from "vscode";
 
 export type Keywords = { [key: string]: string | boolean };
-export type RpgleVariableType = `char` | `varchar` | `int` | `uns` | `packed` | `zoned` | `ind` | `date` | `time` | `timestamp` | `pointer` | `float` | `graph` | `vargraph`;
+export type RpgleVariableType = `char` | `varchar` | `ucs2` | `varucs2` | `int` | `uns` | `packed` | `zoned`  | `float` | `ind` | `date` | `time` | `timestamp` | `pointer` | `graph` | `vargraph`;
 export interface RpgleTypeDetail {
     type?: { name: RpgleVariableType, value?: string };
     reference?: Declaration;
@@ -63,7 +63,7 @@ export namespace LspUtils {
 
             return { reference }
         } else {
-            const validTypes: RpgleVariableType[] = [`char`, `varchar`, `int`, `uns`, `packed`, `zoned`, `ind`, `date`, `time`, `timestamp`, `pointer`, `float`, `graph`, `vargraph`];
+            const validTypes: RpgleVariableType[] = [`char`, `varchar`, `ucs2`, `varucs2`, `int`, `uns`, `packed`, `zoned`, `float`, `ind`, `date`, `time`, `timestamp`, `pointer`, `graph`, `vargraph`];
             const type = Object.keys(keywords).find(key => validTypes.includes(key.toLowerCase() as RpgleVariableType));
             if (type) {
                 return { type: { name: (type.toLowerCase() as RpgleVariableType), value: keywords[type] as string } };

--- a/src/codeActions/testStub.ts
+++ b/src/codeActions/testStub.ts
@@ -459,7 +459,7 @@ export namespace TestStubCodeActions {
             if (detail.type) {
                 declarations.push(`dcl-s ${name} ${detail.type.name}${detail.type.value ? `(${detail.type.value})` : ``};`);
             } else if (detail.reference) {
-                declarations.push(`dcl-ds ${name} likeDs(${detail.reference.name});`);
+                declarations.push(`dcl-ds ${name} likeDs(${detail.reference.name}) inz;`);
             }
         }
 

--- a/src/codeActions/testStub.ts
+++ b/src/codeActions/testStub.ts
@@ -132,7 +132,7 @@ export namespace TestStubCodeActions {
                     const directiveAndControlOptions = [
                         `**free`,
                         ``,
-                        `ctl-opt nomain;`
+                        `ctl-opt nomain ccsidcvt(*excp) ccsid(*jobrun);`
                     ];
 
                     testStubEdit.insert(

--- a/src/codeActions/testStub.ts
+++ b/src/codeActions/testStub.ts
@@ -568,9 +568,11 @@ export namespace TestStubCodeActions {
         switch (type) {
             case `char`:
             case `varchar`:
-            case `graph`:
-            case `vargraph`:
                 return `''`;
+            case `graph`:
+                return `*blanks`;
+            case `vargraph`:
+                return `G''`;
             case `int`:
             case `uns`:
                 return `0`;

--- a/src/codeActions/testStub.ts
+++ b/src/codeActions/testStub.ts
@@ -568,11 +568,11 @@ export namespace TestStubCodeActions {
         switch (type) {
             case `char`:
             case `varchar`:
-                return `''`;
+            case `ucs2`:
+            case `varucs2`:
             case `graph`:
-                return `*blanks`;
             case `vargraph`:
-                return `G''`;
+                return `''`;
             case `int`:
             case `uns`:
                 return `0`;
@@ -583,11 +583,11 @@ export namespace TestStubCodeActions {
             case `ind`:
                 return `*off`;
             case `date`:
-                return `%date('0001-01-01' : *iso)`;
+                return `d'0001-01-01'`;
             case `time`:
-                return `%time('00.00.00' : *iso)`;
+                return `t'00.00.00'`;
             case `timestamp`:
-                return `%timestamp('0001-01-01-00.00.00.000000' : *iso)`;
+                return `z'0001-01-01-00.00.00.000000'`;
             case `pointer`:
                 return `*null`;
             default:
@@ -597,30 +597,26 @@ export namespace TestStubCodeActions {
 
     function getAssertion(type: RpgleVariableType): string {
         switch (type) {
+            case `int`:
+                return `iEqual`;
+            case `ind`:
+                return `nEqual`;
             case `char`:
             case `varchar`:
+            case `ucs2`:
+            case `varucs2`:
             case `graph`:
             case `vargraph`:
-                return `aEqual`;
-            case `int`:
             case `uns`:
-                return `iEqual`;
             case `packed`:
             case `zoned`:
             case `float`:
-                return `assert`;
-            case `ind`:
-                return `nEqual`;
             case `date`:
-                return `assert`;
             case `time`:
-                return `assert`;
             case `timestamp`:
-                return `assert`;
             case `pointer`:
-                return `assert`;
             default:
-                return 'unknown';
+                return `assert`;
         }
     }
 


### PR DESCRIPTION
More improvements to test stub generation as suggested by Barbara:
- [x] Add `inz` keyword for data structures
- [x] Add `ucs2`/`varucs2` data types
- [x] Add `ccsidcvt(*excp) ccsid(*jobrun)`to ctl-opt
  - `ccsidcvt` - Throw an exception if their a ccsid conversion issue
  - `ccsid` - Use actual job ccsid for variables in parameters
- [x] Update default values for data types
- [x] Update assertions 
- [ ] `tgtCcsid` should default to *JOB
- [ ] Code action to test a program
- [ ] Test output capable parameters (parameters passed by reference aka inputs that don't have const or value keyword)
- [ ] Handle dim with %list if less than size 10 or just initialize all items with single assignment