### PR TITLE
auto approving the showTestStubPreview for getting test stub

### DIFF
--- a/src/codeActions/testStub.ts
+++ b/src/codeActions/testStub.ts
@@ -35,13 +35,13 @@ export namespace TestStubCodeActions {
                     }
                 }
             ),
-            commands.registerCommand('vscode-rpgle.generateTestStub', async (document: TextDocument, docs: Cache, exportProcedures: Declaration[]) => {
+            commands.registerCommand('vscode-rpgle.generateTestStub', async (document: TextDocument, docs: Cache, exportProcedures: Declaration[],preference?) => {
                 const ibmi = getInstance();
                 const connection = ibmi!.getConnection()!;
 
                 // Get test stub generation preferences
                 const testStubPreferences = Configuration.getOrFallback<TestStubPreferences>(Section.testStubPreferences);
-                const showTestStubPreview = testStubPreferences["Show Test Stub Preview"];
+                const showTestStubPreview = preference??testStubPreferences["Show Test Stub Preview"];
                 const promptForTestName = testStubPreferences["Prompt For Test Name"];
                 const testSourceFile = testStubPreferences["Test Source File"];
                 const testSourceDirectory = testStubPreferences["Test Source Directory"];


### PR DESCRIPTION
- Earlier, generating the test stub required manual approval.
- With the recent changes, the approval process is automatically handled when the **preference** parameter is passed to the **vscode-rpgle.generateTestStub** command.
- As a result, the test stub generation now works without manual intervention, improving the efficiency of the GenerateTestStubTool by auto approving