### PR TITLE
Re-structure exported API to return test results using result and output loggers

### DIFF
--- a/api/runner.ts
+++ b/api/runner.ts
@@ -786,12 +786,12 @@ export class Runner {
                 const existingLines = existingData.activeLines;
                 const newLines = mappedCoverageData.coverageData.coverage.activeLines;
 
-                for (const [lineStr, covered] of Object.entries(newLines)) {
+                for (const [lineStr, info] of Object.entries(newLines)) {
                     const line = Number(lineStr);
                     if (line in existingLines) {
-                        existingLines[line] = existingLines[line] || covered;
+                        existingLines[line].executed = existingLines[line].executed || info.executed;
                     } else {
-                        existingLines[line] = covered;
+                        existingLines[line] = info;
                     }
                 }
             }

--- a/api/runner.ts
+++ b/api/runner.ts
@@ -41,7 +41,7 @@ export class Runner {
     private testCallbacks: TestCallbacks;
     private testLogger: TestLogger;
     private testMetrics: TestMetrics;
-    private mappedCoverageDatasets: MappedCoverageData[];
+    private mappedCoverageDatasets: MappedCoverageData[] | undefined;
 
     constructor(connection: IBMi, testRequest: TestRequest, testCallbacks: TestCallbacks, testLogger: TestLogger) {
         this.connection = connection;
@@ -56,7 +56,6 @@ export class Runner {
             testFiles: { passed: 0, failed: 0, errored: 0, skipped: 0, cancelled: 0 },
             testCases: { passed: 0, failed: 0, errored: 0, skipped: 0, cancelled: 0 }
         };
-        this.mappedCoverageDatasets = [];
     }
 
     getTestMetrics(): TestMetrics {
@@ -203,13 +202,15 @@ export class Runner {
             }
         }
 
-        const mergedCoverageDatasets = this.mergeCoverageDatasets(this.mappedCoverageDatasets);
-        this.testCallbacks.addCoverageDatasets(mergedCoverageDatasets);
+        if (this.mappedCoverageDatasets) {
+            const mergedCoverageDatasets = this.mergeCoverageDatasets(this.mappedCoverageDatasets);
+            this.testCallbacks.addCoverageDatasets(mergedCoverageDatasets);
 
-        const shouldLogCoverage = this.testCallbacks.shouldLogCoverage();
-        if (shouldLogCoverage) {
-            const coverageThresholds = this.testCallbacks.getCoverageThresholds();
-            await this.testLogger.logCoverage(mergedCoverageDatasets, coverageThresholds);
+            const shouldLogCoverage = this.testCallbacks.shouldLogCoverage();
+            if (shouldLogCoverage) {
+                const coverageThresholds = this.testCallbacks.getCoverageThresholds();
+                await this.testLogger.logCoverage(mergedCoverageDatasets, coverageThresholds);
+            }
         }
         await this.testLogger.logMetrics(this.testMetrics);
         await this.testCallbacks.end();
@@ -625,6 +626,10 @@ export class Runner {
             }
 
             if (testSuite.ccLvl) {
+                if (!this.mappedCoverageDatasets) {
+                    this.mappedCoverageDatasets = [];
+                }
+
                 const codeCoverageParser = new CodeCoverageParser(this.connection, this.testCallbacks, this.testLogger, testSuite.ccLvl);
                 const codeCoverage = await codeCoverageParser.getCoverage(coverageParams!.outStmf);
                 if (codeCoverage) {

--- a/api/testLogger.ts
+++ b/api/testLogger.ts
@@ -273,8 +273,8 @@ export class TestLogger {
             // Calculate line counts
             let coveredLines = 0;
             let uncoveredLines = 0;
-            for (const lineStatus of Object.values(coverageData.activeLines)) {
-                if (lineStatus) {
+            for (const info of Object.values(coverageData.activeLines)) {
+                if (info.executed) {
                     coveredLines++;
                 } else {
                     uncoveredLines++;
@@ -350,5 +350,78 @@ export class TestLogger {
             ...output.split('\n')
         ].join(`\r\n`);
         await this.testResultLogger.append(message);
+
+        for (const coverageData of finalCoverageDatasets) {
+            let parsedCoverageOutput: any;
+            if (coverageData.ccLvl === "*LINE") {
+                const covered: number[] = [];
+                const uncovered: number[] = [];
+
+                for (const [line, info] of Object.entries(coverageData.activeLines)) {
+                    if (info.executed) {
+                        covered.push(Number(line));
+                    } else {
+                        uncovered.push(Number(line));
+                    }
+                }
+
+                parsedCoverageOutput = {
+                    coveredLines: this.compressCoverageRanges(covered),
+                    uncoveredLines: this.compressCoverageRanges(uncovered)
+                };
+            } else {
+                const coveredProcedures: { name: string; line: number }[] = [];
+                const uncoveredProcedures: { name: string; line: number }[] = [];
+
+                for (const [line, info] of Object.entries(coverageData.activeLines)) {
+                    const proc = { name: info.name, line: Number(line) };
+
+                    if (info.executed) {
+                        coveredProcedures.push(proc);
+                    } else {
+                        uncoveredProcedures.push(proc);
+                    }
+                }
+
+                parsedCoverageOutput = {
+                    coveredProcedures,
+                    uncoveredProcedures
+                };
+            }
+
+            await this.testOutputLogger.log(
+                LogLevel.Info,
+                `Code coverage for ${coverageData.uri.fsPath}:\n${JSON.stringify(parsedCoverageOutput, null, 2)}`
+            );
+        }
+    }
+
+    private compressCoverageRanges(lines: number[]): string {
+        if (!lines.length) {
+            return ``;
+        }
+
+        const sorted = [...lines].sort((a, b) => a - b);
+        const ranges: string[] = [];
+
+        let start = sorted[0];
+        let prev = sorted[0];
+
+        for (let i = 1; i < sorted.length; i++) {
+            const current = sorted[i];
+
+            if (current === prev + 1) {
+                prev = current;
+                continue;
+            }
+
+            ranges.push(start === prev ? `${start}` : `${start}-${prev}`);
+            start = current;
+            prev = current;
+        }
+
+        ranges.push(start === prev ? `${start}` : `${start}-${prev}`);
+
+        return ranges.join(", ");
     }
 }

--- a/api/testLogger.ts
+++ b/api/testLogger.ts
@@ -357,11 +357,11 @@ export class TestLogger {
                 const covered: number[] = [];
                 const uncovered: number[] = [];
 
-                for (const [line, info] of Object.entries(coverageData.activeLines)) {
+                for (const [lineStr, info] of Object.entries(coverageData.activeLines)) {
                     if (info.executed) {
-                        covered.push(Number(line));
+                        covered.push(Number(lineStr));
                     } else {
-                        uncovered.push(Number(line));
+                        uncovered.push(Number(lineStr));
                     }
                 }
 
@@ -373,8 +373,8 @@ export class TestLogger {
                 const coveredProcedures: { name: string; line: number }[] = [];
                 const uncoveredProcedures: { name: string; line: number }[] = [];
 
-                for (const [line, info] of Object.entries(coverageData.activeLines)) {
-                    const proc = { name: info.name, line: Number(line) };
+                for (const [lineStr, info] of Object.entries(coverageData.activeLines)) {
+                    const proc = { name: info.name, line: Number(lineStr) };
 
                     if (info.executed) {
                         coveredProcedures.push(proc);

--- a/api/types.ts
+++ b/api/types.ts
@@ -7,6 +7,11 @@ export enum LogLevel {
     Error = 5
 }
 
+export interface LogStorage {
+    shouldStore: boolean,
+    logs: string[]
+}
+
 export interface Logger {
     append: (message: string) => Promise<void>;
     appendWithNotification: (level: LogLevel, message: string, details?: string, buttons?: { label: string, func: () => Promise<void> }[]) => Promise<void>;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -28,7 +28,6 @@ import { exit } from "process";
 import inquirer from "inquirer";
 import pkg from '../package.json';
 import Parser from "vscode-rpgle/language/parser";
-import Cache from "vscode-rpgle/language/models/cache";
 
 interface Options {
     localDirectory?: string;

--- a/cli/src/loggers/summaryLogger.ts
+++ b/cli/src/loggers/summaryLogger.ts
@@ -42,8 +42,8 @@ export class SummaryLogger {
                 // Calculate line counts
                 let coveredLines = 0;
                 let uncoveredLines = 0;
-                for (const lineStatus of Object.values(coverageData.activeLines)) {
-                    if (lineStatus) {
+                for (const info of Object.values(coverageData.activeLines)) {
+                    if (info.executed) {
                         coveredLines++;
                     } else {
                         uncoveredLines++;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "ansi-colors": "^4.1.3",
         "compare-versions": "^6.1.1",
         "node-fetch": "^3.3.2",
         "octokit": "^4.1.2",
@@ -1245,6 +1246,15 @@
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -3780,6 +3790,7 @@
     "node_modules/vscode-rpgle": {
       "version": "0.31.0",
       "resolved": "git+ssh://git@github.com/halcyon-tech/vscode-rpgle.git#464a08316b7432e05a16a5ff7a825d7aef5c5f5f",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -249,6 +249,7 @@
     "preinstall": "cd api && npm install && cd .."
   },
   "dependencies": {
+    "ansi-colors": "^4.1.3",
     "compare-versions": "^6.1.1",
     "node-fetch": "^3.3.2",
     "octokit": "^4.1.2",

--- a/src/codeActions/testStub.ts
+++ b/src/codeActions/testStub.ts
@@ -35,356 +35,359 @@ export namespace TestStubCodeActions {
                     }
                 }
             ),
-            commands.registerCommand('vscode-ibmi-testing.generateTestStub', async (document: TextDocument, docs: Cache, exportProcedures: Declaration[], forcePreferences?: Partial<TestStubPreferences>) => {
-                const ibmi = getInstance();
-                const connection = ibmi!.getConnection()!;
-
-                // Get test stub generation preferences
-                const testStubPreferences = Configuration.getOrFallback<TestStubPreferences>(Section.testStubPreferences);
-                const showTestStubPreview = forcePreferences?.["Show Test Stub Preview"] ?? testStubPreferences["Show Test Stub Preview"];
-                const promptForTestName = testStubPreferences["Prompt For Test Name"];
-                const testSourceFile = testStubPreferences["Test Source File"];
-                const testSourceDirectory = testStubPreferences["Test Source Directory"];
-                const addControlOptionsAndDirectives = testStubPreferences["Add Control Options and Directives"];
-                const addIncludes = testStubPreferences["Add Includes"];
-                const addPrototypes = testStubPreferences["Add Prototypes"];
-                const addStubComments = testStubPreferences["Add Stub Comments"];
-
-                // Build test file name, parent name (directory or source file) and URI
-                let testFileName: string;
-                let testFileParentName: string;
-                let testFileUri: Uri;
-                if (document.uri.scheme === 'file') {
-                    const workspaceFolder = workspace.getWorkspaceFolder(document.uri);
-                    if (workspaceFolder) {
-                        const parsedPath = path.parse(document.uri.fsPath);
-                        testFileName = `${parsedPath.name}.test${parsedPath.ext}`;
-                        testFileParentName = testSourceDirectory;
-
-                        if (promptForTestName) {
-                            const userInput = await promptUserForTestName(testFileParentName, testFileName, true);
-                            if (userInput) {
-                                testFileParentName = userInput.testFileParentName;
-                                testFileName = userInput.testFileName;
-                            } else {
-                                return;
-                            }
-                        }
-
-                        const testFilePath = path.posix.join(workspaceFolder.uri.fsPath, testFileParentName, testFileName);
-                        testFileUri = Uri.file(testFilePath);
-                    } else {
-                        window.showErrorMessage(`No workspace folder found for the document.`);
-                        return;
-                    }
-                } else if (document.uri.scheme === 'member') {
-                    const parsedPath = connection.parserMemberPath(document.uri.path);
-                    testFileName = `${ApiUtils.getSystemNameFromPath(`${parsedPath.name}.test`)}.${parsedPath.extension}`;
-                    testFileParentName = testSourceFile;
-
-                    if (promptForTestName) {
-                        const userInput = await promptUserForTestName(testFileParentName, testFileName, false);
-                        if (userInput) {
-                            testFileParentName = userInput.testFileParentName;
-                            testFileName = userInput.testFileName;
-                        } else {
-                            return;
-                        }
-                    }
-
-                    const testFilePath = parsedPath.asp ?
-                        path.posix.join(parsedPath.asp, parsedPath.library, testFileParentName, testFileName) :
-                        path.posix.join(parsedPath.library, testFileParentName, testFileName);
-                    testFileUri = Uri.from({ scheme: 'member', path: `/${testFilePath}` });
-                } else {
-                    window.showErrorMessage(`Unsupported file type: ${document.uri.scheme}`);
-                    return;
-                }
-
-                if (testFileUri.scheme === 'member') {
-                    const content = connection.getContent();
-
-                    // Check if test source file exists
-                    const parsedPath = connection.parserMemberPath(document.uri.path);
-                    const sourceFileExists = await content.checkObject({ library: parsedPath.library, name: testFileParentName, type: '*FILE' });
-
-                    // Prompt user to create test source file if in preview mode
-                    if (showTestStubPreview) {
-                        if (!sourceFileExists) {
-                            const value = await window.showErrorMessage(`The source file ${parsedPath.library}/${testFileParentName} does not exist. Can it be created?`, { modal: true }, 'Yes', 'No');
-                            if (value === 'No') {
-                                return;
-                            }
-                        }
-                    }
-
-                    // Create test source file if it does not exist
-                    if (!sourceFileExists) {
-                        const createFile = await connection.runCommand({
-                            command: `CRTSRCPF FILE(${parsedPath.library}/${testFileParentName}) RCDLEN(112)`,
-                            noLibList: true
-                        });
-                        if (createFile.code !== 0) {
-                            window.showErrorMessage(`Failed to create ${parsedPath.library}/${testFileParentName}: ${createFile.stderr}`);
-                            return;
-                        }
-                    }
-                }
-
-                // Generate test case spec
-                const testCaseSpecs = await Promise.all(exportProcedures.map(async proc => await getTestCaseSpec(docs, proc, addStubComments)));
-
-                // Build test stub edit and insert code in appropriate places
-                const testStubEdit = new WorkspaceEdit();
-                const testDocs = await LspUtils.getDocs(testFileUri);
-                let testDocument: TextDocument | undefined;
-
-                // Create test file if it does not exist
-                try {
-                    testDocument = await workspace.openTextDocument(testFileUri);
-                } catch (error) {
-                    testStubEdit.createFile(
-                        testFileUri,
-                        {
-                            ignoreIfExists: true
-                        },
-                        {
-                            label: `Create '${testFileName}'`,
-                            needsConfirmation: showTestStubPreview,
-                            iconPath: new ThemeIcon('file')
-                        }
-                    );
-                }
-
-                const text = testDocument ? testDocument.getText() : '';
-                const lastLine = testDocument ? testDocument.lineCount - 1 : 0;
-                function lineAt(line: number): string {
-                    return testDocument ? testDocument.lineAt(line).text : '';
-                }
-
-                // Add directive and control options
-                if (addControlOptionsAndDirectives && text === '') {
-                    const directiveAndControlOptions = [
-                        `**free`,
-                        ``,
-                        `ctl-opt nomain ccsidcvt(*excp) ccsid(*char : *jobrun);`
-                    ];
-
-                    testStubEdit.insert(
-                        testFileUri,
-                        new Position(lastLine, 0),
-                        directiveAndControlOptions.join(`\n`),
-                        {
-                            label: `Add directive and control option(s)`,
-                            needsConfirmation: showTestStubPreview,
-                            iconPath: new ThemeIcon('symbol-misc')
-                        }
-                    );
-                }
-
-                // Add includes
-                if (addIncludes) {
-                    const allIncludes = testCaseSpecs.flatMap(tcs => tcs.includes);
-                    let newIncludes = Array.from(new Map(allIncludes.map(item => [item.name, item])).values());
-                    let newIncludesInsert: { line: number, character: number } = { line: lastLine, character: lineAt(lastLine).length };
-                    let newIncludesTextWrap: { prefix: string, suffix: string } = { prefix: '\n\n', suffix: '' };
-                    if (testDocs) {
-                        try {
-                            // Filter out includes that already exist
-                            newIncludes = newIncludes.filter(include =>
-                                !(text.toLocaleLowerCase().includes(`/include ${include.name}`.toLocaleLowerCase()) || text.toLocaleLowerCase().includes(`/copy ${include.name}`.toLocaleLowerCase())));
-
-                            if (testDocs.includes.length > 0) {
-                                // Insert include after the last existing resolved include
-                                newIncludesInsert.line = Math.max(...testDocs.includes.filter(i => i.fromPath === testFileUri.toString()).map(i => i.line));
-                                newIncludesInsert.character = lineAt(newIncludesInsert.line).length;
-                                newIncludesTextWrap.prefix = `\n`;
-                            } else if (text.toLocaleLowerCase().includes('/copy') || text.toLocaleLowerCase().includes('/include')) {
-                                // Insert include after the last existing unresolved include
-                                const splitText = text.split(/\r?\n/);
-                                for (let i = splitText.length - 1; i >= 0; i--) {
-                                    const line = splitText[i].toLocaleLowerCase().trim();
-                                    if (line.startsWith('/copy') || line.startsWith('/include')) {
-                                        newIncludesInsert.line = i;
-                                        newIncludesInsert.character = lineAt(newIncludesInsert.line).length;
-                                        break;
-                                    }
-                                }
-                                newIncludesTextWrap.prefix = `\n`;
-                            } else if (testDocs.procedures.length > 0) {
-                                // Insert include before the first procedure or prototype
-                                const existingProcOrProto = testDocs.procedures.filter(proc => proc.position?.path === testFileUri.toString());
-                                newIncludesInsert.line = Math.min(...existingProcOrProto.map(proc => proc.range.start!));
-                                newIncludesInsert.character = 0;
-                                newIncludesTextWrap.prefix = ``;
-                                newIncludesTextWrap.suffix = `\n\n`;
-                            }
-                        } catch (error) { }
-                    }
-                    if (newIncludes.length > 0) {
-                        const newIncludesPosition = new Position(newIncludesInsert.line, newIncludesInsert.character);
-                        function insertInclude(text: string) {
-                            testStubEdit.insert(
-                                testFileUri,
-                                newIncludesPosition,
-                                text,
-                                {
-                                    label: `Add include(s)`,
-                                    needsConfirmation: showTestStubPreview,
-                                    iconPath: new ThemeIcon('file-code')
-                                }
-                            );
-                        }
-
-                        // Insert newline prefix
-                        if (newIncludes.length === 1) {
-                            const newIncludeText = `${newIncludesTextWrap.prefix}${newIncludes[0].text}${newIncludesTextWrap.suffix}`;
-                            insertInclude(newIncludeText);
-                        } else {
-                            if (newIncludesTextWrap.prefix !== '') {
-                                insertInclude(newIncludesTextWrap.prefix);
-                            }
-
-                            // Insert includes
-                            for (let i = 0; i < newIncludes.length; i++) {
-                                const newIncludeText = i !== 0 ? `\n${newIncludes[i].text}` : newIncludes[i].text;
-                                insertInclude(newIncludeText);
-                            }
-
-                            // Insert newline suffix
-                            if (newIncludesTextWrap.suffix !== '') {
-                                insertInclude(newIncludesTextWrap.suffix);
-                            }
-                        }
-                    }
-                }
-
-                // Add prototypes
-                if (addPrototypes) {
-                    let newPrototypes: { name: string, text: string[] }[] = testCaseSpecs.flatMap(tcs => tcs.prototype ? tcs.prototype : []);
-                    let newPrototypesInsert: { line: number, character: number } = { line: lastLine, character: lineAt(lastLine).length };
-                    let newPrototypesTextWrap: { prefix: string, suffix: string } = { prefix: '\n\n', suffix: '' };
-                    if (testDocs) {
-                        try {
-                            // Filter out prototypes that already exist
-                            const existingPrototypes = testDocs.procedures.filter(proc => proc.prototype && proc.position?.path === testFileUri.toString());
-                            newPrototypes = newPrototypes.filter(proto => !existingPrototypes.some(existingProto => existingProto.name === proto.name));
-
-                            if (existingPrototypes.length > 0) {
-                                // Insert prototypes after the last existing prototype
-                                newPrototypesInsert.line = Math.max(...existingPrototypes.map(proc => proc.range.end!));
-                                newPrototypesInsert.character = lineAt(newPrototypesInsert.line).length;
-                            } else if (testDocs.procedures.length > 0) {
-                                // Insert prototypes before the first procedure
-                                const existingProcedures = testDocs.procedures.filter(proc => !proc.prototype && proc.position?.path === testFileUri.toString());
-                                newPrototypesInsert.line = Math.min(...existingProcedures.map(proc => proc.range.start!));
-                                newPrototypesInsert.character = 0;
-                                newPrototypesTextWrap.prefix = ``;
-                                newPrototypesTextWrap.suffix = `\n\n`;
-                            }
-                        } catch (error) { }
-                    }
-                    if (newPrototypes.length > 0) {
-                        const newPrototypesPosition = new Position(newPrototypesInsert.line, newPrototypesInsert.character);
-                        function insertPrototype(text: string) {
-                            testStubEdit.insert(
-                                testFileUri,
-                                newPrototypesPosition,
-                                text,
-                                {
-                                    label: `Add prototype(s)`,
-                                    needsConfirmation: showTestStubPreview,
-                                    iconPath: new ThemeIcon('symbol-method')
-                                }
-                            );
-                        }
-
-                        if (newPrototypes.length === 1) {
-                            const newPrototypeText = `${newPrototypesTextWrap.prefix}${newPrototypes[0].text.join('\n')}${newPrototypesTextWrap.suffix}`;
-                            insertPrototype(newPrototypeText);
-                        } else {
-                            // Insert newline prefix
-                            if (newPrototypesTextWrap.prefix !== '') {
-                                insertPrototype(newPrototypesTextWrap.prefix);
-                            }
-
-                            // Insert prototypes
-                            for (let i = 0; i < newPrototypes.length; i++) {
-                                const newPrototypeText = i !== 0 ? `\n\n${newPrototypes[i].text.join('\n')}` : newPrototypes[i].text.join('\n');
-                                insertPrototype(newPrototypeText);
-                            }
-
-                            // Insert newline suffix
-                            if (newPrototypesTextWrap.suffix !== '') {
-                                insertPrototype(newPrototypesTextWrap.suffix);
-                            }
-                        }
-                    }
-                }
-
-                // Add test cases
-                let newTestCases: { name: string, text: string[] }[] = testCaseSpecs.flatMap(tcs => tcs.testCase);
-                let newTestCasesInsert: { line: number, character: number } = { line: lastLine, character: lineAt(lastLine).length };
-                let newTestCasesTextWrap: { prefix: string, suffix: string } = { prefix: '\n\n', suffix: '' };
-                if (testDocs) {
-                    try {
-                        if (testDocs.procedures.length > 0) {
-                            // Insert test case after the last procedure or prototype
-                            const existingProcOrProto = testDocs.procedures.filter(proc => proc.position?.path === testFileUri.toString());
-                            newTestCasesInsert.line = Math.max(...existingProcOrProto.map(proc => proc.range.end!));
-                            newTestCasesInsert.character = lineAt(newTestCasesInsert.line).length;
-                        }
-                    } catch (error) { }
-                }
-                if (newTestCases.length > 0) {
-                    const newTestCasesPosition = new Position(newTestCasesInsert.line, newTestCasesInsert.character);
-                    function insertTestCase(text: string) {
-                        testStubEdit.insert(
-                            testFileUri,
-                            newTestCasesPosition,
-                            text,
-                            {
-                                label: `Add test case(s)`,
-                                needsConfirmation: showTestStubPreview,
-                                iconPath: new ThemeIcon('beaker')
-                            }
-                        );
-                    }
-
-                    if (newTestCases.length === 1) {
-                        const newTestCaseText = `${newTestCasesTextWrap.prefix}${newTestCases[0].text.join('\n')}${newTestCasesTextWrap.suffix}`;
-                        insertTestCase(newTestCaseText);
-                    } else {
-                        // Insert newline prefix
-                        if (newTestCasesTextWrap.prefix !== '') {
-                            insertTestCase(newTestCasesTextWrap.prefix);
-                        }
-
-                        // Insert test cases
-                        for (let i = 0; i < newTestCases.length; i++) {
-                            const newTestCaseText = i !== 0 ? `\n\n${newTestCases[i].text.join('\n')}` : newTestCases[i].text.join('\n');
-                            insertTestCase(newTestCaseText);
-                        }
-
-                        // Insert newline suffix
-                        if (newTestCasesTextWrap.suffix !== '') {
-                            insertTestCase(newTestCasesTextWrap.suffix);
-                        }
-                    }
-                }
-
-                const isApplied = await workspace.applyEdit(testStubEdit);
-                if (isApplied) {
-                    if (!testDocument) {
-                        testDocument = await workspace.openTextDocument(testFileUri);
-                    }
-                    await window.showTextDocument(testDocument);
-                }
-            })
+            commands.registerCommand('vscode-ibmi-testing.generateTestStub', generateTestStub)
         );
     }
 
-    export async function getTestStubCodeActions(document: TextDocument, docs: Cache, range: Range): Promise<CodeAction[] | undefined> {
+    async function generateTestStub(document: TextDocument, docs: Cache, exportProcedures: Declaration[], forcePreferences?: Partial<TestStubPreferences>): Promise<Uri | undefined> {
+        const ibmi = getInstance();
+        const connection = ibmi!.getConnection()!;
+
+        // Get test stub generation preferences
+        const testStubPreferences = Configuration.getOrFallback<TestStubPreferences>(Section.testStubPreferences);
+        const showTestStubPreview = forcePreferences?.["Show Test Stub Preview"] ?? testStubPreferences["Show Test Stub Preview"];
+        const promptForTestName = testStubPreferences["Prompt For Test Name"];
+        const testSourceFile = testStubPreferences["Test Source File"];
+        const testSourceDirectory = testStubPreferences["Test Source Directory"];
+        const addControlOptionsAndDirectives = testStubPreferences["Add Control Options and Directives"];
+        const addIncludes = testStubPreferences["Add Includes"];
+        const addPrototypes = testStubPreferences["Add Prototypes"];
+        const addStubComments = testStubPreferences["Add Stub Comments"];
+
+        // Build test file name, parent name (directory or source file) and URI
+        let testFileName: string;
+        let testFileParentName: string;
+        let testFileUri: Uri;
+        if (document.uri.scheme === 'file') {
+            const workspaceFolder = workspace.getWorkspaceFolder(document.uri);
+            if (workspaceFolder) {
+                const parsedPath = path.parse(document.uri.fsPath);
+                testFileName = `${parsedPath.name}.test${parsedPath.ext}`;
+                testFileParentName = testSourceDirectory;
+
+                if (promptForTestName) {
+                    const userInput = await promptUserForTestName(testFileParentName, testFileName, true);
+                    if (userInput) {
+                        testFileParentName = userInput.testFileParentName;
+                        testFileName = userInput.testFileName;
+                    } else {
+                        return;
+                    }
+                }
+
+                const testFilePath = path.posix.join(workspaceFolder.uri.fsPath, testFileParentName, testFileName);
+                testFileUri = Uri.file(testFilePath);
+            } else {
+                window.showErrorMessage(`No workspace folder found for the document.`);
+                return;
+            }
+        } else if (document.uri.scheme === 'member') {
+            const parsedPath = connection.parserMemberPath(document.uri.path);
+            testFileName = `${ApiUtils.getSystemNameFromPath(`${parsedPath.name}.test`)}.${parsedPath.extension}`;
+            testFileParentName = testSourceFile;
+
+            if (promptForTestName) {
+                const userInput = await promptUserForTestName(testFileParentName, testFileName, false);
+                if (userInput) {
+                    testFileParentName = userInput.testFileParentName;
+                    testFileName = userInput.testFileName;
+                } else {
+                    return;
+                }
+            }
+
+            const testFilePath = parsedPath.asp ?
+                path.posix.join(parsedPath.asp, parsedPath.library, testFileParentName, testFileName) :
+                path.posix.join(parsedPath.library, testFileParentName, testFileName);
+            testFileUri = Uri.from({ scheme: 'member', path: `/${testFilePath}` });
+        } else {
+            window.showErrorMessage(`Unsupported file type: ${document.uri.scheme}`);
+            return;
+        }
+
+        if (testFileUri.scheme === 'member') {
+            const content = connection.getContent();
+
+            // Check if test source file exists
+            const parsedPath = connection.parserMemberPath(document.uri.path);
+            const sourceFileExists = await content.checkObject({ library: parsedPath.library, name: testFileParentName, type: '*FILE' });
+
+            // Prompt user to create test source file if in preview mode
+            if (showTestStubPreview) {
+                if (!sourceFileExists) {
+                    const value = await window.showErrorMessage(`The source file ${parsedPath.library}/${testFileParentName} does not exist. Can it be created?`, { modal: true }, 'Yes', 'No');
+                    if (value === 'No') {
+                        return;
+                    }
+                }
+            }
+
+            // Create test source file if it does not exist
+            if (!sourceFileExists) {
+                const createFile = await connection.runCommand({
+                    command: `CRTSRCPF FILE(${parsedPath.library}/${testFileParentName}) RCDLEN(112)`,
+                    noLibList: true
+                });
+                if (createFile.code !== 0) {
+                    window.showErrorMessage(`Failed to create ${parsedPath.library}/${testFileParentName}: ${createFile.stderr}`);
+                    return;
+                }
+            }
+        }
+
+        // Generate test case spec
+        const testCaseSpecs = await Promise.all(exportProcedures.map(async proc => await getTestCaseSpec(docs, proc, addStubComments)));
+
+        // Build test stub edit and insert code in appropriate places
+        const testStubEdit = new WorkspaceEdit();
+        const testDocs = await LspUtils.getDocs(testFileUri);
+        let testDocument: TextDocument | undefined;
+
+        // Create test file if it does not exist
+        try {
+            testDocument = await workspace.openTextDocument(testFileUri);
+        } catch (error) {
+            testStubEdit.createFile(
+                testFileUri,
+                {
+                    ignoreIfExists: true
+                },
+                {
+                    label: `Create '${testFileName}'`,
+                    needsConfirmation: showTestStubPreview,
+                    iconPath: new ThemeIcon('file')
+                }
+            );
+        }
+
+        const text = testDocument ? testDocument.getText() : '';
+        const lastLine = testDocument ? testDocument.lineCount - 1 : 0;
+        function lineAt(line: number): string {
+            return testDocument ? testDocument.lineAt(line).text : '';
+        }
+
+        // Add directive and control options
+        if (addControlOptionsAndDirectives && text === '') {
+            const directiveAndControlOptions = [
+                `**free`,
+                ``,
+                `ctl-opt nomain ccsidcvt(*excp) ccsid(*char : *jobrun);`
+            ];
+
+            testStubEdit.insert(
+                testFileUri,
+                new Position(lastLine, 0),
+                directiveAndControlOptions.join(`\n`),
+                {
+                    label: `Add directive and control option(s)`,
+                    needsConfirmation: showTestStubPreview,
+                    iconPath: new ThemeIcon('symbol-misc')
+                }
+            );
+        }
+
+        // Add includes
+        if (addIncludes) {
+            const allIncludes = testCaseSpecs.flatMap(tcs => tcs.includes);
+            let newIncludes = Array.from(new Map(allIncludes.map(item => [item.name, item])).values());
+            let newIncludesInsert: { line: number, character: number } = { line: lastLine, character: lineAt(lastLine).length };
+            let newIncludesTextWrap: { prefix: string, suffix: string } = { prefix: '\n\n', suffix: '' };
+            if (testDocs) {
+                try {
+                    // Filter out includes that already exist
+                    newIncludes = newIncludes.filter(include =>
+                        !(text.toLocaleLowerCase().includes(`/include ${include.name}`.toLocaleLowerCase()) || text.toLocaleLowerCase().includes(`/copy ${include.name}`.toLocaleLowerCase())));
+
+                    if (testDocs.includes.length > 0) {
+                        // Insert include after the last existing resolved include
+                        newIncludesInsert.line = Math.max(...testDocs.includes.filter(i => i.fromPath === testFileUri.toString()).map(i => i.line));
+                        newIncludesInsert.character = lineAt(newIncludesInsert.line).length;
+                        newIncludesTextWrap.prefix = `\n`;
+                    } else if (text.toLocaleLowerCase().includes('/copy') || text.toLocaleLowerCase().includes('/include')) {
+                        // Insert include after the last existing unresolved include
+                        const splitText = text.split(/\r?\n/);
+                        for (let i = splitText.length - 1; i >= 0; i--) {
+                            const line = splitText[i].toLocaleLowerCase().trim();
+                            if (line.startsWith('/copy') || line.startsWith('/include')) {
+                                newIncludesInsert.line = i;
+                                newIncludesInsert.character = lineAt(newIncludesInsert.line).length;
+                                break;
+                            }
+                        }
+                        newIncludesTextWrap.prefix = `\n`;
+                    } else if (testDocs.procedures.length > 0) {
+                        // Insert include before the first procedure or prototype
+                        const existingProcOrProto = testDocs.procedures.filter(proc => proc.position?.path === testFileUri.toString());
+                        newIncludesInsert.line = Math.min(...existingProcOrProto.map(proc => proc.range.start!));
+                        newIncludesInsert.character = 0;
+                        newIncludesTextWrap.prefix = ``;
+                        newIncludesTextWrap.suffix = `\n\n`;
+                    }
+                } catch (error) { }
+            }
+            if (newIncludes.length > 0) {
+                const newIncludesPosition = new Position(newIncludesInsert.line, newIncludesInsert.character);
+                function insertInclude(text: string) {
+                    testStubEdit.insert(
+                        testFileUri,
+                        newIncludesPosition,
+                        text,
+                        {
+                            label: `Add include(s)`,
+                            needsConfirmation: showTestStubPreview,
+                            iconPath: new ThemeIcon('file-code')
+                        }
+                    );
+                }
+
+                // Insert newline prefix
+                if (newIncludes.length === 1) {
+                    const newIncludeText = `${newIncludesTextWrap.prefix}${newIncludes[0].text}${newIncludesTextWrap.suffix}`;
+                    insertInclude(newIncludeText);
+                } else {
+                    if (newIncludesTextWrap.prefix !== '') {
+                        insertInclude(newIncludesTextWrap.prefix);
+                    }
+
+                    // Insert includes
+                    for (let i = 0; i < newIncludes.length; i++) {
+                        const newIncludeText = i !== 0 ? `\n${newIncludes[i].text}` : newIncludes[i].text;
+                        insertInclude(newIncludeText);
+                    }
+
+                    // Insert newline suffix
+                    if (newIncludesTextWrap.suffix !== '') {
+                        insertInclude(newIncludesTextWrap.suffix);
+                    }
+                }
+            }
+        }
+
+        // Add prototypes
+        if (addPrototypes) {
+            let newPrototypes: { name: string, text: string[] }[] = testCaseSpecs.flatMap(tcs => tcs.prototype ? tcs.prototype : []);
+            let newPrototypesInsert: { line: number, character: number } = { line: lastLine, character: lineAt(lastLine).length };
+            let newPrototypesTextWrap: { prefix: string, suffix: string } = { prefix: '\n\n', suffix: '' };
+            if (testDocs) {
+                try {
+                    // Filter out prototypes that already exist
+                    const existingPrototypes = testDocs.procedures.filter(proc => proc.prototype && proc.position?.path === testFileUri.toString());
+                    newPrototypes = newPrototypes.filter(proto => !existingPrototypes.some(existingProto => existingProto.name === proto.name));
+
+                    if (existingPrototypes.length > 0) {
+                        // Insert prototypes after the last existing prototype
+                        newPrototypesInsert.line = Math.max(...existingPrototypes.map(proc => proc.range.end!));
+                        newPrototypesInsert.character = lineAt(newPrototypesInsert.line).length;
+                    } else if (testDocs.procedures.length > 0) {
+                        // Insert prototypes before the first procedure
+                        const existingProcedures = testDocs.procedures.filter(proc => !proc.prototype && proc.position?.path === testFileUri.toString());
+                        newPrototypesInsert.line = Math.min(...existingProcedures.map(proc => proc.range.start!));
+                        newPrototypesInsert.character = 0;
+                        newPrototypesTextWrap.prefix = ``;
+                        newPrototypesTextWrap.suffix = `\n\n`;
+                    }
+                } catch (error) { }
+            }
+            if (newPrototypes.length > 0) {
+                const newPrototypesPosition = new Position(newPrototypesInsert.line, newPrototypesInsert.character);
+                function insertPrototype(text: string) {
+                    testStubEdit.insert(
+                        testFileUri,
+                        newPrototypesPosition,
+                        text,
+                        {
+                            label: `Add prototype(s)`,
+                            needsConfirmation: showTestStubPreview,
+                            iconPath: new ThemeIcon('symbol-method')
+                        }
+                    );
+                }
+
+                if (newPrototypes.length === 1) {
+                    const newPrototypeText = `${newPrototypesTextWrap.prefix}${newPrototypes[0].text.join('\n')}${newPrototypesTextWrap.suffix}`;
+                    insertPrototype(newPrototypeText);
+                } else {
+                    // Insert newline prefix
+                    if (newPrototypesTextWrap.prefix !== '') {
+                        insertPrototype(newPrototypesTextWrap.prefix);
+                    }
+
+                    // Insert prototypes
+                    for (let i = 0; i < newPrototypes.length; i++) {
+                        const newPrototypeText = i !== 0 ? `\n\n${newPrototypes[i].text.join('\n')}` : newPrototypes[i].text.join('\n');
+                        insertPrototype(newPrototypeText);
+                    }
+
+                    // Insert newline suffix
+                    if (newPrototypesTextWrap.suffix !== '') {
+                        insertPrototype(newPrototypesTextWrap.suffix);
+                    }
+                }
+            }
+        }
+
+        // Add test cases
+        let newTestCases: { name: string, text: string[] }[] = testCaseSpecs.flatMap(tcs => tcs.testCase);
+        let newTestCasesInsert: { line: number, character: number } = { line: lastLine, character: lineAt(lastLine).length };
+        let newTestCasesTextWrap: { prefix: string, suffix: string } = { prefix: '\n\n', suffix: '' };
+        if (testDocs) {
+            try {
+                if (testDocs.procedures.length > 0) {
+                    // Insert test case after the last procedure or prototype
+                    const existingProcOrProto = testDocs.procedures.filter(proc => proc.position?.path === testFileUri.toString());
+                    newTestCasesInsert.line = Math.max(...existingProcOrProto.map(proc => proc.range.end!));
+                    newTestCasesInsert.character = lineAt(newTestCasesInsert.line).length;
+                }
+            } catch (error) { }
+        }
+        if (newTestCases.length > 0) {
+            const newTestCasesPosition = new Position(newTestCasesInsert.line, newTestCasesInsert.character);
+            function insertTestCase(text: string) {
+                testStubEdit.insert(
+                    testFileUri,
+                    newTestCasesPosition,
+                    text,
+                    {
+                        label: `Add test case(s)`,
+                        needsConfirmation: showTestStubPreview,
+                        iconPath: new ThemeIcon('beaker')
+                    }
+                );
+            }
+
+            if (newTestCases.length === 1) {
+                const newTestCaseText = `${newTestCasesTextWrap.prefix}${newTestCases[0].text.join('\n')}${newTestCasesTextWrap.suffix}`;
+                insertTestCase(newTestCaseText);
+            } else {
+                // Insert newline prefix
+                if (newTestCasesTextWrap.prefix !== '') {
+                    insertTestCase(newTestCasesTextWrap.prefix);
+                }
+
+                // Insert test cases
+                for (let i = 0; i < newTestCases.length; i++) {
+                    const newTestCaseText = i !== 0 ? `\n\n${newTestCases[i].text.join('\n')}` : newTestCases[i].text.join('\n');
+                    insertTestCase(newTestCaseText);
+                }
+
+                // Insert newline suffix
+                if (newTestCasesTextWrap.suffix !== '') {
+                    insertTestCase(newTestCasesTextWrap.suffix);
+                }
+            }
+        }
+
+        const isApplied = await workspace.applyEdit(testStubEdit);
+        if (isApplied) {
+            if (!testDocument) {
+                testDocument = await workspace.openTextDocument(testFileUri);
+            }
+            await window.showTextDocument(testDocument);
+            return testFileUri;
+        }
+    }
+
+    async function getTestStubCodeActions(document: TextDocument, docs: Cache, range: Range): Promise<CodeAction[] | undefined> {
         const codeActions: CodeAction[] = [];
 
         const exportProcedures = docs.procedures.filter(proc => !proc.prototype && proc.keyword[`EXPORT`]);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,13 +8,13 @@ import { CodeCov } from "./components/codeCov";
 import * as tmp from "tmp";
 import { TestOutputLogger } from "./loggers/testOutputLogger";
 import { TestStubCodeActions } from "./codeActions/testStub";
-import { IBMiTestingApi } from "./types";
+import { IBMiTesting } from "./types";
 
 export let testOutputLogger: TestOutputLogger = new TestOutputLogger();
 export let manager: IBMiTestManager | undefined;
 let userLibraryList: string[] | undefined;
 
-export async function activate(context: ExtensionContext): Promise<IBMiTestingApi> {
+export async function activate(context: ExtensionContext): Promise<IBMiTesting> {
 	console.log('Congratulations, your extension "vscode-ibmi-testing" is now active!');
 	const installedVersion = context.extension.packageJSON.version;
 	await testOutputLogger.log(LogLevel.Info, `IBM i Testing (v${installedVersion}) extension activated!`);
@@ -102,7 +102,7 @@ export async function activate(context: ExtensionContext): Promise<IBMiTestingAp
 	tmp.setGracefulCleanup();
 
 	return {
-		getManager: () => {
+		getTestManager: () => {
 			return manager;
 		}
 	};

--- a/src/fileCoverage.ts
+++ b/src/fileCoverage.ts
@@ -11,8 +11,8 @@ export class IBMiFileCoverage extends FileCoverage {
         super(uri, new TestCoverageCount(0, 0));
         this.isStatementCoverage = mergedCoverageData.ccLvl === '*LINE';
 
-        for (const [line, info] of Object.entries(mergedCoverageData.activeLines)) {
-            const linePosition = new Position(Number(line) - 1, 0);
+        for (const [lineStr, info] of Object.entries(mergedCoverageData.activeLines)) {
+            const linePosition = new Position(Number(lineStr) - 1, 0);
             if (this.isStatementCoverage) {
                 this.lines.push(new StatementCoverage(info.executed, linePosition));
                 this.statementCoverage.covered += info.executed ? 1 : 0;

--- a/src/loggers/testOutputLogger.ts
+++ b/src/loggers/testOutputLogger.ts
@@ -1,11 +1,16 @@
 import { LogOutputChannel, window } from "vscode";
-import { Logger, LogLevel } from "../../api/types";
+import { Logger, LogLevel, LogStorage } from "../../api/types";
 
 export class TestOutputLogger implements Logger {
     private logOutputChannel: LogOutputChannel;
+    private logStorage: LogStorage;
 
     constructor() {
         this.logOutputChannel = window.createOutputChannel('IBM i Testing', { log: true });
+        this.logStorage = {
+            shouldStore: false,
+            logs: []
+        };
     }
 
     async append(message: string): Promise<void> {
@@ -42,26 +47,45 @@ export class TestOutputLogger implements Logger {
     }
 
     async log(level: LogLevel, message: string): Promise<void> {
+
+        let storedLog: string | undefined;
         switch (level) {
             case LogLevel.Trace:
                 this.logOutputChannel.trace(message);
+                storedLog = `[trace] ${message}`;
                 break;
             case LogLevel.Debug:
                 this.logOutputChannel.debug(message);
+                storedLog = `[debug] ${message}`;
                 break;
             case LogLevel.Info:
                 this.logOutputChannel.info(message);
+                storedLog = `[info] ${message}`;
                 break;
             case LogLevel.Warning:
                 this.logOutputChannel.warn(message);
+                storedLog = `[warning] ${message}`;
                 break;
             case LogLevel.Error:
                 this.logOutputChannel.error(message);
+                storedLog = `[error] ${message}`;
                 break;
+        }
+
+        if (this.logStorage.shouldStore && storedLog) {
+            this.logStorage.logs.push(storedLog);
         }
     }
 
     public show() {
         this.logOutputChannel.show();
+    }
+
+    public getStoredLogs(): LogStorage {
+        return this.logStorage;
+    }
+
+    public setStoredLogs(logStorage: LogStorage) {
+        this.logStorage = logStorage;
     }
 }

--- a/src/loggers/testResultLogger.ts
+++ b/src/loggers/testResultLogger.ts
@@ -1,15 +1,25 @@
 import { TestRun } from "vscode";
-import { Logger, LogLevel } from "../../api/types";
+import { Logger, LogLevel, LogStorage } from "../../api/types";
+import c from "ansi-colors";
 
 export class TestResultLogger implements Logger {
     private testRun: TestRun;
+    private logStorage: LogStorage;
 
     constructor(testRun: TestRun) {
         this.testRun = testRun;
+        this.logStorage = {
+            shouldStore: true,
+            logs: []
+        };
     }
 
     async append(message: string): Promise<void> {
         this.testRun.appendOutput(message);
+
+        if(this.logStorage.shouldStore) {
+            this.logStorage.logs.push(c.unstyle(message));
+        }
     }
 
     async log(level: LogLevel, message: string): Promise<void> {
@@ -18,5 +28,9 @@ export class TestResultLogger implements Logger {
 
     async appendWithNotification(level: LogLevel, message: string, details?: string, buttons?: { label: string; func: () => Promise<void>; }[]): Promise<void> {
         // Not used
+    }
+
+    public getStoredLogs(): LogStorage {
+        return this.logStorage;
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,10 @@
 import { IBMiTestManager } from "./manager";
 
-export interface IBMiTestingApi {
-    getManager: () => IBMiTestManager | undefined;
+export interface TestRunResult {
+    testResultLogs: string[];
+    testOutputLogs: string[];
+}
+
+export interface IBMiTesting {
+    getTestManager: () => IBMiTestManager | undefined;
 }


### PR DESCRIPTION
- [x] Re-structure exported API to return test results using result and output loggers
- [x] Fixes #198
- [x] Add code coverage summary to test results