### PR TITLE
Fix retrieval of `stdout` when using `runCommand`

### DIFF
--- a/api/runner.ts
+++ b/api/runner.ts
@@ -404,7 +404,7 @@ export class Runner {
         let compileResult: any;
         try {
             const env = testBucket.uri.scheme === 'file' ? await this.testCallbacks.getEnvConfig(testBucketPath) : {};
-            compileResult = await this.connection.runCommand({ command: compileCommand, environment: `ile`, env: env });
+            compileResult = await this.connection.runCommand({ command: compileCommand, environment: `ile`, env: env, getSpooledFiles: true });
         } catch (error: any) {
             await this.testLogger.logCompilation(testSuite.name, 'errored', [error.message ? error.message : error]);
             this.testMetrics.compilations.errored++;
@@ -582,7 +582,7 @@ export class Runner {
             let testResult: any;
             try {
                 const env = testBucket.uri.scheme === 'file' ? await this.testCallbacks.getEnvConfig(testBucketPath) : {};
-                testResult = await this.connection.runCommand({ command: testCommand, environment: `ile`, env: env });
+                testResult = await this.connection.runCommand({ command: testCommand, environment: `ile`, env: env, getSpooledFiles: true });
             } catch (error: any) {
                 const assertionResult: AssertionResult[] = [{
                     outcome: 'error',

--- a/api/runner.ts
+++ b/api/runner.ts
@@ -404,7 +404,7 @@ export class Runner {
         let compileResult: any;
         try {
             const env = testBucket.uri.scheme === 'file' ? await this.testCallbacks.getEnvConfig(testBucketPath) : {};
-            compileResult = await this.connection.runCommand({ command: compileCommand, environment: `ile`, env: env, getSpooledFiles: true });
+            compileResult = await this.connection.runCommand({ command: compileCommand, environment: `ile`, env: env, getSpooledFiles: true } as any);
         } catch (error: any) {
             await this.testLogger.logCompilation(testSuite.name, 'errored', [error.message ? error.message : error]);
             this.testMetrics.compilations.errored++;
@@ -582,7 +582,7 @@ export class Runner {
             let testResult: any;
             try {
                 const env = testBucket.uri.scheme === 'file' ? await this.testCallbacks.getEnvConfig(testBucketPath) : {};
-                testResult = await this.connection.runCommand({ command: testCommand, environment: `ile`, env: env, getSpooledFiles: true });
+                testResult = await this.connection.runCommand({ command: testCommand, environment: `ile`, env: env, getSpooledFiles: true } as any);
             } catch (error: any) {
                 const assertionResult: AssertionResult[] = [{
                     outcome: 'error',

--- a/src/components/rpgUnit.ts
+++ b/src/components/rpgUnit.ts
@@ -69,7 +69,7 @@ export class RPGUnit implements IBMiComponent {
                             return 'NeedsUpdate';
                         }
                     } else {
-                        await testOutputLogger.log(LogLevel.Error, `No copyright information found for RPGUnit`);
+                        await testOutputLogger.log(LogLevel.Error, `Failed to get installed version of RPGUnit as copyright string format changed.`);
                         return 'NeedsUpdate';
                     }
                 } else {


### PR DESCRIPTION
### Changes
- Switch from `DSPSRVPGM` to `QSYS2.PROGRAM_INFO` for copyright retrieval
- Use `getSpooledFiles` for `runCommand` calls