### PR TITLE
Generate default test config when creating stubs for the first time

### DIFF
--- a/api/config.ts
+++ b/api/config.ts
@@ -35,9 +35,11 @@ export class LocalConfigHandler implements ConfigHandler {
                 await this.testOutputLogger.log(LogLevel.Info, `Found global testing configuration at ${globalConfigPath}:\n${JSON.stringify(globalConfig, null, 2)}`);
             }
 
-            const mergedConfig = lodash.merge({}, globalConfig, directoryConfig);
-            await this.testOutputLogger.log(LogLevel.Info, `Merged testing configuration:\n${JSON.stringify(mergedConfig, null, 2)}`);
-            return mergedConfig;
+            if (globalConfig || directoryConfig) {
+                const mergedConfig = lodash.merge({}, globalConfig, directoryConfig);
+                await this.testOutputLogger.log(LogLevel.Info, `Merged testing configuration:\n${JSON.stringify(mergedConfig, null, 2)}`);
+                return mergedConfig;
+            }
         } catch (error: any) {
             await this.testOutputLogger.appendWithNotification(LogLevel.Error, `Failed to retrieve testing configuration`, error);
             return;
@@ -109,9 +111,11 @@ export class IfsConfigHandler implements ConfigHandler {
                 await this.testOutputLogger.log(LogLevel.Info, `Found global testing configuration at ${globalConfigPath.toString()}:\n${JSON.stringify(globalConfig, null, 2)}`);
             }
 
-            const mergedConfig = lodash.merge({}, globalConfig, directoryConfig);
-            await this.testOutputLogger.log(LogLevel.Info, `Merged testing configuration:\n${JSON.stringify(mergedConfig, null, 2)}`);
-            return mergedConfig;
+            if (globalConfig || directoryConfig) {
+                const mergedConfig = lodash.merge({}, globalConfig, directoryConfig);
+                await this.testOutputLogger.log(LogLevel.Info, `Merged testing configuration:\n${JSON.stringify(mergedConfig, null, 2)}`);
+                return mergedConfig;
+            }
         } catch (error: any) {
             await this.testOutputLogger.appendWithNotification(LogLevel.Error, `Failed to retrieve testing configuration`, error);
             return;
@@ -194,9 +198,11 @@ export class QsysConfigHandler implements ConfigHandler {
                 await this.testOutputLogger.log(LogLevel.Info, `Found global testing configuration at ${globalConfigPath}:\n${JSON.stringify(globalConfig, null, 2)}`);
             }
 
-            const mergedConfig = lodash.merge({}, globalConfig, memberConfig);
-            await this.testOutputLogger.log(LogLevel.Info, `Merged testing configuration:\n${JSON.stringify(mergedConfig, null, 2)}`);
-            return mergedConfig;
+            if (globalConfig || memberConfig) {
+                const mergedConfig = lodash.merge({}, globalConfig, memberConfig);
+                await this.testOutputLogger.log(LogLevel.Info, `Merged testing configuration:\n${JSON.stringify(mergedConfig, null, 2)}`);
+                return mergedConfig;
+            }
         } catch (error: any) {
             await this.testOutputLogger.appendWithNotification(LogLevel.Error, `Failed to retrieve testing configuration`, error);
             return;

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
               "Test Source File": "QTESTSRC",
               "Test Source Directory": "qtestsrc",
               "Prompt For Test Name": false,
+              "Generate Default Test Configuration": true,
               "Add Control Options and Directives": true,
               "Add Includes": true,
               "Add Prototypes": true,
@@ -101,6 +102,10 @@
                 "type": "boolean",
                 "default": false
               },
+              "Generate Default Test Configuration": {
+                "type": "boolean",
+                "default": true
+              },
               "Add Control Options and Directives": {
                 "type": "boolean",
                 "default": true
@@ -119,7 +124,7 @@
               }
             },
             "additionalProperties": false,
-            "markdownDescription": "Preferences for how test stubs should be generated:\n* `Show Test Stub Preview`: Controls whether to show a preview of the test stub before adding it to the file or source member. This refactoring preview can also be used to selectively insert portions of the stub.\n* `Test Source File`: The default source file to generate new test members into.\n* `Test Source Directory`: The default directory to generate new test files into.\n* `Prompt For Test Name`: Controls whether to prompt for the name of the test including where it is located. The default source file is set using the `Test Source File` preference, the default directory is set using the `Test Source Directory` preference, and the test file or member will be named according to the rules described [here](https://codefori.github.io/docs/developing/testing/writing/#test-suites).\n* `Add Control Options and Directives`: Controls whether to add control options (`ctl-opt nomain ccsidcvt(*excp) ccsid(*char : *jobrun);`) and directives (`**free`) for new test files or members.\n* `Add Includes`: Controls whether to generate relevant includes.\n* `Add Prototypes`: Controls whether to generate a prototype for the procedure being tested (if it does not already exist).\n* `Add Stub Comments`: Controls whether to add comments to the test stub to distinguish inputs, actual results, expected results, and assertions."
+            "markdownDescription": "Preferences for how test stubs should be generated:\n* `Show Test Stub Preview`: Controls whether to show a preview of the test stub before adding it to the file or source member. This refactoring preview can also be used to selectively insert portions of the stub.\n* `Test Source File`: The default source file to generate new test members into.\n* `Test Source Directory`: The default directory to generate new test files into.\n* `Prompt For Test Name`: Controls whether to prompt for the name of the test including where it is located. The default source file is set using the `Test Source File` preference, the default directory is set using the `Test Source Directory` preference, and the test file or member will be named according to the rules described [here](https://codefori.github.io/docs/developing/testing/writing/#test-suites).\n* `Generate Default Test Configuration`: Controls whether a default `testing.json` should be created alongside the generated test when no existing configuration is found.\n* `Add Control Options and Directives`: Controls whether to add control options (`ctl-opt nomain ccsidcvt(*excp) ccsid(*char : *jobrun);`) and directives (`**free`) for new test files or members.\n* `Add Includes`: Controls whether to generate relevant includes.\n* `Add Prototypes`: Controls whether to generate a prototype for the procedure being tested (if it does not already exist).\n* `Add Stub Comments`: Controls whether to add comments to the test stub to distinguish inputs, actual results, expected results, and assertions."
           },
           "IBM i Testing.libraryListValidation": {
             "order": 3,

--- a/src/codeActions/index.ts
+++ b/src/codeActions/index.ts
@@ -96,6 +96,7 @@ export namespace TestStubCodeActions {
 
         // Create test file if it does not exist
         try {
+            await workspace.fs.stat(testFileLocation.testFileUri);
             testDocument = await workspace.openTextDocument(testFileLocation.testFileUri);
         } catch (error) {
             testStubEdit.createFile(
@@ -109,6 +110,34 @@ export namespace TestStubCodeActions {
                     iconPath: new ThemeIcon('file')
                 }
             );
+        }
+
+        let testConfig: { uri: Uri, content: string } | undefined;
+        if (testStubPreferences["Generate Default Test Configuration"]) {
+            testConfig = await TestStubGenerator.generateTestConfig(document.uri, testFileLocation.testFileUri, connection);
+            if (testConfig) {
+                testStubEdit.createFile(
+                    testConfig.uri,
+                    {
+                        ignoreIfExists: true
+                    },
+                    {
+                        label: `Create 'testing.json'`,
+                        needsConfirmation: testStubPreferences["Show Test Stub Preview"],
+                        iconPath: new ThemeIcon('settings-gear')
+                    }
+                );
+                testStubEdit.insert(
+                    testConfig.uri,
+                    new Position(0, 0),
+                    testConfig.content,
+                    {
+                        label: `Add default testing configuration`,
+                        needsConfirmation: testStubPreferences["Show Test Stub Preview"],
+                        iconPath: new ThemeIcon('settings-gear')
+                    }
+                );
+            }
         }
 
         const text = testDocument ? testDocument.getText() : '';
@@ -331,15 +360,23 @@ export namespace TestStubCodeActions {
         const isApplied = await workspace.applyEdit(testStubEdit);
         if (isApplied) {
             return await window.withProgress({ location: ProgressLocation.Window }, async () => {
+                // Open the newly created test configuration
+                if (testConfig) {
+                    const testConfigDocument = await workspace.openTextDocument(testConfig.uri);
+                    if (testConfigDocument.isDirty) {
+                        await testConfigDocument.save();
+                    }
+                    await window.showTextDocument(testConfigDocument, { preview: false });
+                }
+
+                // Open the generated test
                 if (!testDocument) {
                     testDocument = await workspace.openTextDocument(testFileLocation.testFileUri);
                 }
-
                 if (testDocument.isDirty) {
                     await testDocument.save();
                 }
-
-                await window.showTextDocument(testDocument);
+                await window.showTextDocument(testDocument, { preview: false });
 
                 if (document.uri.scheme === 'member') {
                     commands.executeCommand("code-for-ibmi.refreshObjectBrowser");

--- a/src/codeActions/testStubGenerator.ts
+++ b/src/codeActions/testStubGenerator.ts
@@ -5,7 +5,9 @@ import { getInstance } from "../extensions/ibmi";
 import { LspUtils, RpgleTypeDetail, RpgleVariableType } from "./lspUtils";
 import * as path from "path";
 import { ApiUtils } from "../../api/apiUtils";
+import { LocalConfigHandler, QsysConfigHandler } from "../../api/config";
 import { Configuration, Section, TestStubPreferences } from "../configuration";
+import { testOutputLogger } from "../extension";
 import IBMi from "@halcyontech/vscode-ibmi-types/api/IBMi";
 
 export interface TestCaseSpec {
@@ -78,6 +80,69 @@ export namespace TestStubGenerator {
             testFileParentName,
             testFileUri
         };
+    }
+
+    export async function generateTestConfig(uri: Uri, testFileUri: Uri, connection?: IBMi): Promise<{ uri: Uri, content: string } | undefined> {
+        const defaultTestConfig = {
+            "rpgunit": {
+                "rucrtrpg": {
+                    "tgtCcsid": "*JOB",
+                    "dbgView": "*SOURCE",
+                    "rpgPpOpt": "*LVL2",
+                    "cOption": [
+                        "*EVENTF"
+                    ]
+                },
+                "rucalltst": {
+                    "order": "*API",
+                    "libl": "*CURRENT",
+                    "jobD": "*DFT",
+                    "detail": "*BASIC",
+                    "output": "*ALLWAYS",
+                    "rclRsc": "*NO",
+                    "onFailure": "*ABORT"
+                }
+            },
+            "codecov": {
+                "module": []
+            }
+        };
+
+        if (uri.scheme === 'file') {
+            const workspaceFolder = workspace.getWorkspaceFolder(uri);
+            if (!workspaceFolder) {
+                return;
+            }
+
+            const configHandler = new LocalConfigHandler(testOutputLogger, workspaceFolder.uri.fsPath, testFileUri.fsPath);
+            const existingConfig = await configHandler.getConfig();
+            if (existingConfig) {
+                return;
+            }
+
+            const configPath = path.join(testFileUri.fsPath, '..', 'testing.json');
+
+            return {
+                uri: Uri.file(configPath),
+                content: JSON.stringify(defaultTestConfig, null, 4)
+            };
+        } else if (uri.scheme === 'member' && connection) {
+            const configHandler = new QsysConfigHandler(connection as any, testOutputLogger, testFileUri.path);
+            const existingConfig = await configHandler.getConfig();
+            if (existingConfig) {
+                return;
+            }
+
+            const parsedTestPath = connection.parserMemberPath(testFileUri.path);
+            const configPath = parsedTestPath.asp ?
+                path.posix.join(parsedTestPath.asp, parsedTestPath.library, parsedTestPath.file, 'testing.json') :
+                path.posix.join(parsedTestPath.library, parsedTestPath.file, 'testing.json');
+
+            return {
+                uri: Uri.from({ scheme: 'member', path: `/${configPath}` }),
+                content: JSON.stringify(defaultTestConfig, null, 4)
+            };
+        }
     }
 
     async function promptUserForTestName(testFileParentName: string, testFileName: string, isLocal: boolean): Promise<{ testFileParentName: string, testFileName: string } | undefined> {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -6,6 +6,7 @@ export interface TestStubPreferences {
     "Test Source File": string;
     "Test Source Directory": string;
     "Prompt For Test Name": boolean;
+    "Generate Default Test Configuration": boolean;
     "Add Control Options and Directives": boolean;
     "Add Includes": boolean;
     "Add Prototypes": boolean;
@@ -41,6 +42,7 @@ export const defaultConfigurations: { [T in Section]: ValueType } = {
         "Test Source File": "QTESTSRC",
         "Test Source Directory": "qtestsrc",
         "Prompt For Test Name": false,
+        "Generate Default Test Configuration": true,
         "Add Control Options and Directives": true,
         "Add Includes": true,
         "Add Prototypes": true,


### PR DESCRIPTION
### Linked Issue
Fixes https://github.com/IBM/vscode-ibmi-testing/issues/208

### Changes
This PR adds support for generating a default test configuration file if one does not exist both locally and globally.