### PR TITLE
Remove temporary API `runCommand` cast

### DIFF
--- a/api/runner.ts
+++ b/api/runner.ts
@@ -405,7 +405,7 @@ export class Runner {
         let compileResult: any;
         try {
             const env = testBucket.uri.scheme === 'file' ? await this.testCallbacks.getEnvConfig(testBucketPath) : {};
-            compileResult = await this.connection.runCommand({ command: compileCommand, environment: `ile`, env: env, getSpooledFiles: true } as any);
+            compileResult = await this.connection.runCommand({ command: compileCommand, environment: `ile`, env: env, getSpooledFiles: true });
         } catch (error: any) {
             await this.testLogger.logCompilation(testSuite.name, 'errored', [error.message ? error.message : error]);
             this.testMetrics.compilations.errored++;
@@ -583,7 +583,7 @@ export class Runner {
             let testResult: any;
             try {
                 const env = testBucket.uri.scheme === 'file' ? await this.testCallbacks.getEnvConfig(testBucketPath) : {};
-                testResult = await this.connection.runCommand({ command: testCommand, environment: `ile`, env: env, getSpooledFiles: true } as any);
+                testResult = await this.connection.runCommand({ command: testCommand, environment: `ile`, env: env, getSpooledFiles: true });
             } catch (error: any) {
                 const assertionResult: AssertionResult[] = [{
                     outcome: 'error',


### PR DESCRIPTION
### Changes

Remove temporary casts to `any` we previously had when using `getSpooledFiles` due to old Code for IBM i types