### PR TITLE
Support `wrapperCmd` for code coverage

### DIFF
--- a/api/runner.ts
+++ b/api/runner.ts
@@ -522,8 +522,8 @@ export class Runner {
             // Merge base execution params (ie. from VS Code settings) and execution params from config file
             const baseExecutionParams = this.testCallbacks.getBaseExecutionParams(qualifiedTstPgm, xmlStmf, testCase?.name);
             const rucalltst = testSuite.testingConfig?.rpgunit?.rucalltst;
-            const wrapperCmd = testSuite.testingConfig?.rpgunit?.rucalltst?.wrapperCmd;
-            if (wrapperCmd) {
+            const rucalltstWrapperCmd = testSuite.testingConfig?.rpgunit?.rucalltst?.wrapperCmd;
+            if (rucalltstWrapperCmd) {
                 delete rucalltst?.wrapperCmd;
             }
             const testParams: RUCALLTST = {
@@ -550,15 +550,16 @@ export class Runner {
             let testCommand = content.toCl(`${productLibrary}/RUCALLTST`, testParams as any);
 
             // Wrap call tests command if a wrapper command is specified
-            if (wrapperCmd && wrapperCmd.cmd) {
-                const cmd = `${wrapperCmd.cmd}(${testCommand})`;
-                const params = wrapperCmd.params || {};
+            if (rucalltstWrapperCmd && rucalltstWrapperCmd.cmd) {
+                const cmd = `${rucalltstWrapperCmd.cmd}(${testCommand})`;
+                const params = rucalltstWrapperCmd.params || {};
                 testCommand = content.toCl(cmd, params);
             }
 
             // Build CODECOV command if code coverage is enabled
             let coverageParams: CODECOV | undefined;
             if (testSuite.ccLvl) {
+                const codecovWrapperCmd = testSuite.testingConfig?.codecov?.wrapperCmd;
                 coverageParams = {
                     cmd: testCommand,
                     module: [],
@@ -576,7 +577,16 @@ export class Runner {
                 coverageParams.module = coverageParams.module.map((m: string) => `(${m})`);
 
                 const flattenedCoverageParams = ApiUtils.flattenCommandParams(coverageParams);
-                testCommand = `QDEVTOOLS/CODECOV CMD(${flattenedCoverageParams.cmd}) MODULE(${flattenedCoverageParams.module}) CCLVL(${flattenedCoverageParams.ccLvl}) OUTSTMF('${flattenedCoverageParams.outStmf}')`;
+                const codecovCommand = `QDEVTOOLS/CODECOV CMD(${flattenedCoverageParams.cmd}) MODULE(${flattenedCoverageParams.module}) CCLVL(${flattenedCoverageParams.ccLvl}) OUTSTMF('${flattenedCoverageParams.outStmf}')`;
+
+                // Wrap CODECOV command if a wrapper command is specified
+                if (codecovWrapperCmd && codecovWrapperCmd.cmd) {
+                    const cmd = `${codecovWrapperCmd.cmd}(${codecovCommand})`;
+                    const params = codecovWrapperCmd.params || {};
+                    testCommand = content.toCl(cmd, params);
+                } else {
+                    testCommand = codecovCommand;
+                }
             }
             await this.testLogger.testOutputLogger.log(LogLevel.Info, `Running ${testSuite.name}: ${testCommand}`);
 

--- a/api/runner.ts
+++ b/api/runner.ts
@@ -579,7 +579,7 @@ export class Runner {
                 const flattenedCoverageParams = ApiUtils.flattenCommandParams(coverageParams);
                 const codecovCommand = `QDEVTOOLS/CODECOV CMD(${flattenedCoverageParams.cmd}) MODULE(${flattenedCoverageParams.module}) CCLVL(${flattenedCoverageParams.ccLvl}) OUTSTMF('${flattenedCoverageParams.outStmf}')`;
 
-                // Wrap CODECOV command if a wrapper command is specified
+                // Wrap code coverage command if a wrapper command is specified
                 if (codecovWrapperCmd && codecovWrapperCmd.cmd) {
                     const cmd = `${codecovWrapperCmd.cmd}(${codecovCommand})`;
                     const params = codecovWrapperCmd.params || {};

--- a/api/types.ts
+++ b/api/types.ts
@@ -155,7 +155,7 @@ export interface TestingConfig {
         rucrtcbl?: RUCRTCBL & { wrapperCmd?: WrapperCmd },
         rucalltst?: RUCALLTST & { wrapperCmd?: WrapperCmd }
     },
-    codecov?: CODECOV
+    codecov?: CODECOV & { wrapperCmd?: WrapperCmd }
 }
 
 export interface RUCRTRPG {

--- a/schemas/testing.json
+++ b/schemas/testing.json
@@ -721,6 +721,32 @@
                         "default": ""
                     },
                     "markdownDescription": "Exclude\n\nObjects to exclude"
+                },
+                "wrapperCmd": {
+                    "type": "object",
+                    "markdownDescription": "Wrapper Command\n\nSpecifies a custom command to wrap the `CODECOV` command.",
+                    "default": {
+                        "cmd": "",
+                        "params": {}
+                    },
+                    "properties": {
+                        "cmd": {
+                            "type": "string",
+                            "default": "",
+                            "markdownDescription": "Command\n\nSpecifies the custom command."
+                        },
+                        "params": {
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": [
+                                    "string",
+                                    "number"
+                                ]
+                            },
+                            "markdownDescription": "Parameters\n\nSpecifies the parameters for the custom command."
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Linked Issues

Fixes https://github.com/IBM/vscode-ibmi-testing/issues/229

### Changes

Adds support for the `wrapperCmd` for code coverage to allow wrapping the entire code coverage command with a custom CL command.

### How To Test

1. Set the `wrapperCmd` in the `testing.json`
2. Run the tests with code coverage
3. Observe the command and parameters are used as seen in the `IBM i Testing` output channel

### Checklist

<!-- Put an `x` in the relevant boxes -->

- [x] Tested locally
- [x] Removed all `console.log` statements
- [x] Verified extension types pass (`npm run webpack`)
- [x] Verified CLI types pass (`npm run webpack`)
- [x] Updated relevant documentation [here](https://github.com/codefori/docs/tree/main/src/content/docs/developing/testing)